### PR TITLE
CORE-686 fix _canonical key for Clause mappings

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -427,7 +427,7 @@
 
     , Clause: {
         _mixins: ["section_base"]
-      , "canonical" : {
+      , _canonical: {
         contracts : "Contract"
       }
       , contracts: Proxy(


### PR DESCRIPTION
Typo was causing errors when attempting to map Contracts to Clauses 