### PR TITLE
CORE-795 Workflow cycles sometimes don't activate

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -552,6 +552,8 @@ def calculate_min_start_date_and_max_end_date_for_workflow_from_basedate(workflo
         min_start_date = start_date
       if max_end_date is None or end_date > max_end_date:
         max_end_date = end_date
+  if max_end_date < min_start_date:
+    max_end_date = max_end_date + RelativeTimeboxed.freq_to_delta(workflow.frequency)
   return min_start_date, max_end_date
 
 # Check if workflow should be Inactive after cycle status change


### PR DESCRIPTION
This solves the issue in the story and makes creating new cycles more consistent (cycle is created if start_date <= today < end_date), but we are far away from the having the behaviour in Kostya's updated sheet: https://docs.google.com/a/reciprocitylabs.com/spreadsheet/ccc?key=0Avyi_GigOIL5dGlMVlBOT0VST2U2UjNXQUF3dVRPaXc&usp=gmail#gid=122 