### PR TITLE
db_migrate was failing because roles table was not created

### DIFF
--- a/src/ggrc_basic_permissions/migrations/versions/20141217235626_51e046bb002_ensure_all_audit_leads_have_program_.py
+++ b/src/ggrc_basic_permissions/migrations/versions/20141217235626_51e046bb002_ensure_all_audit_leads_have_program_.py
@@ -2,14 +2,14 @@
 """Ensure all Audit Leads have Program Editor role or better
 
 Revision ID: 51e046bb002
-Revises: 5156e813935f
+Revises: 581a9621fac1
 Create Date: 2014-12-17 23:56:26.323023
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '51e046bb002'
-down_revision = '5156e813935f'
+down_revision = '581a9621fac1'
 
 from alembic import op
 import sqlalchemy as sa
@@ -19,7 +19,7 @@ def upgrade():
 
     #1: remove programreader roles for assignees (they need to be program editor)
     op.execute("""
-      DELETE ur 
+      DELETE ur
       FROM user_roles ur, contexts c, audits a, roles r, programs p
       WHERE a.program_id=p.id AND p.context_id=c.id AND ur.context_id=c.id AND ur.role_id=r.id
       AND a.contact_id=ur.person_id


### PR DESCRIPTION
We need this in the patch because otherwise we'll need to reverse migrations in the next release...

From https://github.com/reciprocity/ggrc-core/pull/2119:

This moves the 'Ensure all Audit Leads have Program Editor role or better' migration from the ggrc into ggrc_basic_permissions. This is because running db_migrate on an empty db fails to execute the delete clause because the user_roles table does not exist yet.