### PR TITLE
put back the first line to readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 gGRC-Core
 *********
 
+Google Governance, Risk and Compliance. Migrated from `Google <https://code.google.com/p/compliance-management/>`_ `Code <https://code.google.com/p/ggrc-core>`_.
+
 Requirements
 ============
 


### PR DESCRIPTION
this was removed by accident when updating the readme file for ansiblethis was removed by accident when updating the readme file for ansible.