### PR TITLE
Add benchmarking for response creation/dispatch

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -676,10 +676,12 @@ class Resource(ModelView):
 
     if 'If-None-Match' in self.request.headers and \
         self.request.headers['If-None-Match'] == self.etag(object_for_json):
-      return current_app.make_response((
-        '', 304, [('Etag', self.etag(object_for_json))]))
-    return self.json_success_response(
-      object_for_json, self.modified_at(obj))
+      with benchmark("Make response"):
+        return current_app.make_response((
+          '', 304, [('Etag', self.etag(object_for_json))]))
+    with benchmark("Make response"):
+      return self.json_success_response(
+        object_for_json, self.modified_at(obj))
 
   def validate_headers_for_put_or_delete(self, obj):
     missing_headers = []
@@ -750,8 +752,9 @@ class Resource(ModelView):
       update_memcache_after_commit(self.request)
     with benchmark("Serialize collection"):
       object_for_json = self.object_for_json(obj)
-    return self.json_success_response(
-        object_for_json, self.modified_at(obj))
+    with benchmark("Make response"):
+      return self.json_success_response(
+          object_for_json, self.modified_at(obj))
 
   def delete(self, id):
     if 'X-Appengine-Taskname' not in request.headers:
@@ -892,8 +895,9 @@ class Resource(ModelView):
       return current_app.make_response((
         '', 304, [('Etag', self.etag(collection))]))
 
-    return self.json_success_response(
-      collection, self.collection_last_modified(), cache_op=cache_op)
+    with benchmark("Make response"):
+      return self.json_success_response(
+        collection, self.collection_last_modified(), cache_op=cache_op)
 
   def get_resources_from_cache(self, matches):
     """Get resources from cache for specified matches"""
@@ -997,8 +1001,9 @@ class Resource(ModelView):
       update_memcache_after_commit(self.request)
     with benchmark("Serialize object"):
       object_for_json = self.object_for_json(obj)
-    return self.json_success_response(
-      object_for_json, self.modified_at(obj), id=obj.id, status=201)
+    with benchmark("Make response"):
+      return self.json_success_response(
+        object_for_json, self.modified_at(obj), id=obj.id, status=201)
 
   @classmethod
   def add_to(cls, app, url, model_class=None, decorators=()):


### PR DESCRIPTION
In the interest in tracking down why responses from the server take multiple seconds while the underlying query and serialization take half a second, I'm adding benchmarking to the creation of the response.