### PR TITLE
Fix task mappings

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -108,7 +108,7 @@
           current_cycle: CustomFilter("cycles", function(result) {
               return result.instance.attr("is_current");
             }),
-          current_task_groups: Cross("current_cycle", "reify_cycle_task_groups"),
+          current_task_groups: Cross("current_cycle", "cycle_task_groups"),
           current_task_group_objects: Cross("current_task_groups", "cycle_task_group_objects_for_page_object"),
           current_tasks: Cross("current_task_groups", "cycle_task_group_object_tasks_for_page_object"),
           current_all_tasks: Cross("current_task_groups", "cycle_task_group_tasks"),


### PR DESCRIPTION
@sasmita514 this should fix the issue you were having - you can merge it because it's against your branch.

By the way, I think your code will a lot more readable if you don't write callbacks like:

```
dfd.then(function(s){
  s.refresh().then(function(refreshed_s){
    ...
  })
})
```
but
```
dfd.then(function(s){
  return s.refresh()
}).then(function(refreshed_s){
  ...
});
```
Or in your case
```
GGRC.Models.Search.search_for_types('', ['Workflow'], {contact_id: GGRC.current_user.id})
      .then(function(result_set){
          var wf_data = result_set.getResultsForType('Workflow');
          //FIX ME Load data 10 each time
          var refresh_queue = new RefreshQueue();
          refresh_queue.enqueue(wf_data);
          refresh_queue.trigger().then(function(options){
            var wf, i, tasklist;
            for (i = 0; i < options.length; i++){
              wf=options[i];
              console.log(wf);
              wf.get_binding('current_all_tasks').refresh_instances().then(function(d){
                //console.log(d.length);
              });

              //self.update_tasks_for_workflow(wf);
              console.log(wf);
            }
            //Create a view and update here
            if(options.length > 0)
              self.insert_options(options, my_view, component_class, prepend);
          });
      });
```
would be better as:
```
GGRC.Models.Search.search_for_types('', ['Workflow'], {contact_id: GGRC.current_user.id})
      .then(function(result_set){
          var wf_data = result_set.getResultsForType('Workflow');
          //FIX ME Load data 10 each time
          var refresh_queue = new RefreshQueue();
          refresh_queue.enqueue(wf_data);
          return refresh_queue.trigger();
      }).then(function(options){
        var wf, i, tasklist;
        wfs = options;
        return $.when.apply($, can.map(options, function(wf){
          return wf.get_binding('current_all_tasks').refresh_instances();
        }));
      }).then(function() {
        console.log(arguments); // current_all_tasks lists
        if(wfs.length > 0)
          self.insert_options(wfs, my_view, component_class, prepend);
      });
```

@bmomberger-reciprocity there seems to be an issue with Reify list loader - it's breaking the binding chain in some cases. I'll look into it when I have the time, but if you have any ideas why this is happening please let me know. 