### PR TITLE
CORE-976 Script error when creating audit

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -548,6 +548,7 @@
       , context: Direct("Context", "related_object", "context")
       , contexts_via_audits: Cross("audits", "context")
       , program_authorized_people: Cross("context", "authorized_people")
+      , program_authorizations: Cross("context", "user_roles")
       , authorization_contexts: Multi(["context", "contexts_via_audits"])
       , authorizations_via_contexts: Cross("authorization_contexts", "user_roles")
       , authorizations: Cross("authorization_contexts", "user_roles")


### PR DESCRIPTION
This bug was caused by: https://github.com/reciprocity/ggrc-core/pull/2154 which removed the `program_authorizations` line from mappings.js.