### PR TITLE
gitignore sass autocompilation cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Session.vim
 COMMIT_MSG
 
 node_modules
+
+# Some editors automagically compile sass
+src/**/.sass-cache
+src/**/_*.css


### PR DESCRIPTION
Some editors (like my emacs setup) automatically compile sass files. This produces some debris.