### PR TITLE
CORE-323 grant private Program read permissions when mapped from a Response

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -365,21 +365,23 @@ def handle_relationship_post(sender, obj=None, src=None, service=None):
             ContextImplication.source_context_id == obj.source.context.id))\
       .count() < 1:
     #Create the audit -> program implication for the Program added to the Response
-    db.session.add(ContextImplication(
-      source_context=obj.source.context,
-      context=obj.destination.context,
-      source_context_scope='Audit',
-      context_scope='Program',
-      modified_by=get_current_user(),
-      ))
+    parent_program = obj.source.request.audit.program
+    if(parent_program != obj.destination):
+      db.session.add(ContextImplication(
+        source_context=obj.source.context,
+        context=obj.destination.context,
+        source_context_scope='Audit',
+        context_scope='Program',
+        modified_by=get_current_user(),
+        ))
 
-    db.session.add(ContextImplication(
-      source_context=obj.source.request.audit.program.context,
-      context=obj.destination.context,
-      source_context_scope='Program',
-      context_scope='Program',
-      modified_by=get_current_user(),
-      ))
+      db.session.add(ContextImplication(
+        source_context=parent_program.context,
+        context=obj.destination.context,
+        source_context_scope='Program',
+        context_scope='Program',
+        modified_by=get_current_user(),
+        ))
 
 # When adding a private program to an Audit Response, ensure Auditors
 #  can read it

--- a/src/ggrc_basic_permissions/contributed_roles.py
+++ b/src/ggrc_basic_permissions/contributed_roles.py
@@ -161,6 +161,11 @@ class BasicRoleImplications(DeclarativeRoleImplications):
       ('Audit', None): {
         'Auditor': ['AuditorReader'],
         },
+      ('Program', 'Program'): {
+        'ProgramOwner': ['ProgramReader'],
+        'ProgramEditor': ['ProgramReader'],
+        'ProgramReader': ['ProgramReader'],
+        },
       ('Program', None): {
         'ProgramOwner': ['ProgramBasicReader'],
         'ProgramEditor': ['ProgramBasicReader'],

--- a/src/ggrc_basic_permissions/migrations/versions/20150123215041_3bb32fb65d47_make_audit_role_implications_to_private_.py
+++ b/src/ggrc_basic_permissions/migrations/versions/20150123215041_3bb32fb65d47_make_audit_role_implications_to_private_.py
@@ -1,0 +1,83 @@
+
+"""Make audit role implications to private programs mapped via responses
+
+Revision ID: 3bb32fb65d47
+Revises: 51e046bb002
+Create Date: 2015-01-23 21:50:41.635827
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3bb32fb65d47'
+down_revision = '51e046bb002'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+  op.execute("""
+    INSERT INTO context_implications (
+      source_context_id, source_context_scope, context_id, context_scope
+      )
+    SELECT DISTINCT rs.context_id as source_context_id,
+                    'Audit' AS source_context_scope, 
+                    p.context_id,
+                    'Program' AS context_scope
+    FROM relationships r
+    INNER JOIN responses rs 
+      ON rs.id = r.source_id 
+      AND r.source_type IN ('Response', 'DocumentationResponse', 
+        'InterviewResponse')
+    INNER JOIN programs p 
+      ON p.id = r.destination_id 
+      AND r.destination_type = 'Program'
+    WHERE p.private = 1 
+    AND (SELECT count(*) from context_implications 
+         WHERE source_context_id = rs.context_id 
+         AND context_id = p.context_id) < 1
+    """)
+
+  op.execute("""
+    INSERT INTO context_implications (
+      source_context_id, source_context_scope, context_id, context_scope
+      )
+    SELECT DISTINCT sp.context_id as source_context_id,
+                    'Program' AS source_context_scope, 
+                    p.context_id,
+                    'Program' AS context_scope
+    FROM relationships r
+    INNER JOIN responses rs 
+      ON rs.id = r.source_id 
+      AND r.source_type IN ('Response', 'DocumentationResponse', 
+        'InterviewResponse')
+    INNER JOIN requests rqs
+      ON rqs.id = rs.request_id
+    INNER JOIN audits a
+      ON a.id = rqs.audit_id
+    INNER JOIN programs sp
+      ON sp.id = a.program_id
+    INNER JOIN programs p 
+      ON p.id = r.destination_id 
+      AND r.destination_type = 'Program'
+    WHERE p.private = 1 
+    AND (SELECT count(*) from context_implications 
+         WHERE source_context_id = sp.context_id 
+         AND context_id = p.context_id) < 1
+    """)
+
+def downgrade():
+  op.execute("""
+    DELETE context_implications 
+    FROM context_implications ci
+    INNER JOIN audits a ON a.context_id = ci.source_context_id
+    INNER JOIN programs p ON p.context_id = ci.context_id
+    WHERE a.program_id != p.id
+    """)
+
+  op.execute("""
+    DELETE context_implications 
+    FROM context_implications ci
+    INNER JOIN programs sp ON sp.context_id = ci.source_context_id
+    INNER JOIN programs p ON p.context_id = ci.context_id
+    """)


### PR DESCRIPTION
This PR creates context implications under thses circumstances:<br>* A Response is mapped to a private program<br>* The private program is not the same program as the Audit's program<br>* An implication does not already exist to this Program from the Audit<BR><BR>The implication grants ProgramReader for all authorized people to the source Program, and AuditProgramReader for all authorized people in the Audit containing the mapped Response.<BR><BR>When all mappings from all Reponses in the parent Program to the other Program are destroyed, the context implication is removed.