### PR TITLE
CORE-329 add objects to My Work when user is secondary contact

### DIFF
--- a/src/ggrc/fulltext/mysql.py
+++ b/src/ggrc/fulltext/mysql.py
@@ -210,7 +210,7 @@ class MysqlIndexer(SqlIndexer):
           ).distinct()
         type_union_queries.append(model_type_query)
 
-      # Objects for which the user is the "contact"
+      # Objects for which the user is the "contact" or "secondary contact"
       if hasattr(model, 'contact_id'):
         model_type_query = db.session.query(
             model.id.label('id'),
@@ -220,6 +220,17 @@ class MysqlIndexer(SqlIndexer):
               model.contact_id == contact_id
           ).distinct()
         type_union_queries.append(model_type_query)
+      # Objects for which the user is the "contact"
+      if hasattr(model, 'secondary_contact_id'):
+        model_type_query = db.session.query(
+            model.id.label('id'),
+            type_column.label('type'),
+            literal(None).label('context_id')
+          ).filter(
+              model.secondary_contact_id == contact_id
+          ).distinct()
+        type_union_queries.append(model_type_query)
+
 
       if model is all_models.Control:
         # Control also has `principal_assessor` and `secondary_assessor`


### PR DESCRIPTION
I forgot to add this in when adding secondary contact columns to objects.  This extends the My Work search query to also check when user is the secondary contact.