### PR TITLE
Show Cycle Tasks above Cycle Objects in Cycle view

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -189,11 +189,6 @@
       draw_children: true,
       child_options: [
         {
-          title: 'Objects',
-          model: "CycleTaskGroupObject",
-          mapping: "cycle_task_group_objects",
-          allow_creating: false
-        }, {
           title: 'Tasks',
           model: "CycleTaskGroupObjectTask",
           mapping: "cycle_task_group_tasks",
@@ -262,7 +257,7 @@
     tree_view_options: {
       show_view: _mustache_path + "/tree.mustache",
       //footer_view: _mustache_path + "/tree_footer.mustache",
-      draw_children: true,
+      draw_children: false,
       child_options: [
         {
           model: "CycleTaskGroupObjectTask",
@@ -311,6 +306,11 @@
         {
           model: "CycleTaskEntry",
           mapping: "cycle_task_entries",
+          allow_creating: true
+        },
+        {
+          model: "CycleTaskGroupObject",
+          mapping: "cycle_task_group_object",
           allow_creating: true
         }
       ]

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
@@ -62,7 +62,7 @@
                   </div>
                 </li>
                 <li>
-                  {{#with_mapping_count instance 'cycle_task_entries'}}
+                  {{#with_mapping_count instance 'cycle_task_group_object'}}
                   <span class="counter" rel="tooltip" data-placement="left" data-original-title="# of comments">
                     <i class="grcicon-object-black"></i>
                     <strong class="error">{{count}}</strong>
@@ -109,7 +109,14 @@
   {{#if expanded}}
   <div class="tier-2-info item-content">
     <div class="tier-2-info-content">
-
+      {{#if draw_children}}
+        {{#child_options.1}}
+          <div class="inner-tree {{^if list.length}}hide{{/list}}">
+            <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
+          </div>
+        {{/child_options.1}}
+      {{/if}}
+      <!--
       {{#is_allowed 'update' instance context='for'}}
       <div class="details-wrap">
         <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
@@ -252,7 +259,7 @@
       {{/if}}
 
       </section>
-
+      -->
     </div>
   </div>
   {{/if}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/tree.mustache
@@ -27,14 +27,6 @@
                 <li>
                   {{{renderLive '/static/mustache/tasks/states.mustache' status=instance.status}}}
                 </li>
-                <li>
-                  {{#with_mapping_count instance 'cycle_task_group_object_tasks'}}
-                  <span class="counter" rel="tooltip" data-placement="left" data-original-title="# of tasks">
-                    <i class="grcicon-task-black"></i>
-                    <strong class="error">{{count}}</strong>
-                  </span>
-                  {{/with_mapping_count}}
-                </li>
               </ul>
             </div>
           </div>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/tree.mustache
@@ -24,6 +24,14 @@
             </div>
             <div class="span4">
               <ul class="tree-action-list">
+                {{#with_mapping_count instance 'cycle_task_group_tasks'}}
+                  <li>
+                    <span class="counter" rel="tooltip" data-placement="left" data-original-title="# of mapped tasks">
+                      <i class="grcicon-task-black"></i>
+                      <strong class="error">{{count}}</strong>
+                    </span>
+                  </li>
+                {{/with_mapping_count}}
                 <li>
                 {{#using cycle=instance.cycle}}
                   {{#if_equals cycle.is_current true}}
@@ -57,22 +65,6 @@
                   {{/if_equals}}
                 {{/using}}
                 </li>
-                {{#with_mapping_count instance 'cycle_task_group_objects'}}
-                  <li>
-                    <span class="counter" rel="tooltip" data-placement="left" data-original-title="# of mapped objects">
-                      <i class="grcicon-object-black"></i>
-                      <strong class="error">{{count}}</strong>
-                    </span>
-                  </li>
-                {{/with_mapping_count}}
-                {{#with_mapping_count instance 'cycle_task_group_tasks'}}
-                  <li>
-                    <span class="counter" rel="tooltip" data-placement="left" data-original-title="# of mapped tasks">
-                      <i class="grcicon-task-black"></i>
-                      <strong class="error">{{count}}</strong>
-                    </span>
-                  </li>
-                {{/with_mapping_count}}
               </ul>
             </div>
           </div>
@@ -91,6 +83,7 @@
           </div>
         {{/child_options}}
       {{/if}}
+      <!--
       <div class="show-description">
         <div class="row-fluid">
           <div class="span12">
@@ -105,6 +98,7 @@
           </div>
         </div>
       </div>
+       -->
     </div>
   </div>
   {{/if}}


### PR DESCRIPTION
I've added the needs work label because we are planning to discuss these changes later today.