### PR TITLE
Fix script error when top nav dropdown is shown

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -616,8 +616,6 @@ can.Control("CMS.Controllers.InnerNav", {
         remain_height = win_height - footer_height,
         win_width = win.width();
 
-        console.log(dropdown_height);
-
       if(win_width - left_pos < 322) {
         $dropdown.addClass("right-pos");
       } else {

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -606,7 +606,6 @@ can.Control("CMS.Controllers.InnerNav", {
     ".dropdown-toggle click": function(el, ev) {
       var $dropdown = el.closest(".hidden-widgets-list").find(".dropdown-menu"),
         $menu_item = $dropdown.find(".inner-nav-item").find("a"),
-        dropdown_height = $dropdown.outerHeight(),
         offset = el.offset(),
         top_pos = offset.top + 36,
         left_pos = offset.left,
@@ -620,11 +619,6 @@ can.Control("CMS.Controllers.InnerNav", {
         $dropdown.addClass("right-pos");
       } else {
         $dropdown.removeClass("right-pos");
-      }
-      if(remain_height - top_pos < dropdown_height) {
-        $dropdown.addClass("mid-pos");
-      } else {
-        $dropdown.removeClass("mid-pos");
       }
       if($menu_item.length === 1) {
         $dropdown.addClass("one-item");

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -606,6 +606,7 @@ can.Control("CMS.Controllers.InnerNav", {
     ".dropdown-toggle click": function(el, ev) {
       var $dropdown = el.closest(".hidden-widgets-list").find(".dropdown-menu"),
         $menu_item = $dropdown.find(".inner-nav-item").find("a"),
+        dropdown_height = $dropdown.outerHeight(),
         offset = el.offset(),
         top_pos = offset.top + 36,
         left_pos = offset.left,
@@ -615,10 +616,17 @@ can.Control("CMS.Controllers.InnerNav", {
         remain_height = win_height - footer_height,
         win_width = win.width();
 
+        console.log(dropdown_height);
+
       if(win_width - left_pos < 322) {
         $dropdown.addClass("right-pos");
       } else {
         $dropdown.removeClass("right-pos");
+      }
+      if(remain_height - top_pos < dropdown_height) {
+        $dropdown.addClass("mid-pos");
+      } else {
+        $dropdown.removeClass("mid-pos");
       }
       if($menu_item.length === 1) {
         $dropdown.addClass("one-item");

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -620,11 +620,6 @@ can.Control("CMS.Controllers.InnerNav", {
       } else {
         $dropdown.removeClass("right-pos");
       }
-      if(remain_height - top_pos < dropdown_height) {
-        $dropdown.addClass("mid-pos");
-      } else {
-        $dropdown.removeClass("mid-pos");
-      }
       if($menu_item.length === 1) {
         $dropdown.addClass("one-item");
       } else {


### PR DESCRIPTION
@vladan-mitevski The script error was caused because dropdown_height is not defined anywhere. I have tried adding $dropdown.height(), but the .mid-pos class just breaks positioning when there is no vertical space, so I removed it completely.