### PR TITLE
Updated code to show only top 5 workflows in dashboard, CORE-959

### DIFF
--- a/src/ggrc/assets/mustache/dashboard/info/info.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/info.mustache
@@ -39,9 +39,10 @@
         {{#if workflow_view}}
           <section class="widget small-margin">
             <header class="header">
-              <h2>Workflow Progress</h2>
+              <h2>My Workflows({{workflow_count}})</h2>
             </header>
-          {{{ renderLive workflow_view }}}
+            {{{ renderLive workflow_view }}}
+            <a href="javascript://" class="workflow-trigger show-all">Show all my workflows</a>
           </section>
         {{/if}}
         {{#if task_view}}

--- a/src/ggrc/assets/mustache/dashboard/info/workflow_progress.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/workflow_progress.mustache
@@ -50,7 +50,7 @@
               </div>
               <ul class="item-util">
                 <li>
-                  {{ins.task_data.task_count}} tasks in total / {{ins.task_data.finished_percentage}}% finished
+                  {{ins.task_data.task_count}} tasks in total / {{ins.task_data.verified_percentage}}% completed
                 </li>
               </ul>
             </div>

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -1269,3 +1269,10 @@ p {
     font-weight: normal;
   }
 }
+
+.workflow-trigger {
+  font-size: 12px;
+  float: right;
+  display: inline-block;
+  margin-top: 6px;
+}


### PR DESCRIPTION
This code
- Filters workflows with current cycle/tasks
- Sorts list of currect-workflows ascending  order  w.r.t first end date.
- Shows only first 5 workflows initially
- Have a show/hide link to show all workflows, if the workflows are less than 5, this option is hidden

-minor % bug fixes 