### PR TITLE
Feature/dashboard audit tab core 1020

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -137,6 +137,7 @@ dashboard-js-template-files:
   - dashboard/info/my_tasks.mustache
   - dashboard/info/task_filters.mustache
   - dashboard/info/wf_owner.mustache
+  - dashboard/info/my_audits.mustache
   - data_assets/modal_content.mustache
   - documents/active_column.mustache
   - dashboard/lhn.mustache

--- a/src/ggrc/assets/mustache/dashboard/info/info.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/info.mustache
@@ -45,32 +45,33 @@
             <a href="javascript://" class="workflow-trigger show-all">Show all my workflows</a>
           </section>
         {{/if}}
-        {{#if task_view}}
-          <section class="widget dashboard small-margin">
-            <header class="header widget-nav">
-              <div class="row-fluid">
-                <div class="span12">
-                  <ul>
-                    <li class="active">
-                      <a href="javascript://">
-                        My Tasks ({{task_count}})
-                      </a>
-                    </li>
-                    <!--li>
-                      <a href="#">
-                        Audit Requests (2)
-                      </a>
-                    </li-->
-                  </ul>
-                </div>
+
+        <section class="widget dashboard small-margin">
+          <header class="header widget-nav">
+            <div class="row-fluid">
+              <div class="span12">
+                <ul>
+                  <li class="active task-tab">
+                    <a href="javascript://">
+                      My Tasks ({{task_count}})
+                    </a>
+                  </li>
+                  <li class="audit-tab">
+                    <a href="javascript://">
+                      Audit Requests ({{audit_count}})
+                    </a>
+                  </li>
+                </ul>
               </div>
-            </header>
-            <section class="content">
-              {{> /static/mustache/dashboard/info/task_filters.mustache}}
-              {{{ renderLive task_view }}}
-            </section>
-          </section><!-- Widget end -->
-        {{/if}}
+            </div>
+          </header>
+          <section class="content"> 
+            {{> /static/mustache/dashboard/info/task_filters.mustache}}
+            {{{ renderLive task_view }}}
+            {{{ renderLive audit_view }}}
+          </section>
+        </section><!-- Widget end -->
+
       </div><!-- inner-content end -->
     </div>
   </div>

--- a/src/ggrc/assets/mustache/dashboard/info/my_audits.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/my_audits.mustache
@@ -18,12 +18,55 @@
           		<div class="row-fluid">
           			<span class="status-label status-{{to_class instance.status '_'}}"></span>
         				<!--i class="grcicon-arrow-right"></i-->
-        				<div class="span4">
-		              <div class="title tree-title-area">
-		                {{instance.title}}
+								<div class="span6">
+		              <div class="tree-title-area w-status">
+		                <a href="{{instance.viewLink}}">{{instance.title}}</a>
+		                <ul class="item-util">
+                      <li>
+                        {{#using program=instance.program}}
+                          Program: <a href="{{program.viewLink}}">{{program.title}}</a>
+                        {{/using}}
+                      </li>
+                      <li>
+												{{#if instance.contact}}
+			                    {{#using contact=instance.contact}}
+			                      Owner: {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
+			                    {{/using}}
+			                  {{else}}
+			                    Owner: Not defined
+			                  {{/if}}
+                      </li>
+	                   </ul>
 		              </div>
 		            </div>
-								
+		            <div class="span4">
+									<div class="tree-title-area">
+		                Status: {{instance.status}}
+		              </div>
+		            </div>
+		            <div class="span1">
+									<ul class="tree-action-list">
+										{{#with_page_object_as 'page_object'}}
+		                  {{#if_instance_of page_object 'Person'}}
+		                    {{#mapping_count instance 'related_owned_objects'}}
+		                      <li>
+		                        <span class="counter" rel="tooltip" data-placement="left" data-original-title="# of requests">
+		                          <i class="grcicon-object-black"></i>
+		                          {{.}}
+		                        </span>
+		                      </li>
+		                      {{else}}
+		                      <li>
+		                        <span class="counter" rel="tooltip" data-placement="left" data-original-title="# of requests">
+		                          <i class="grcicon-object-black"></i>
+		                            ...
+		                        </span>
+		                      </li>
+		                    {{/mapping_count}}
+		                  {{/if_instance_of}}
+		                {{/with_page_object_as}}
+									</ul>
+		            </div>
 							</div> <!-- row-fluid end -->
 						</div> <!-- item-data end -->
 					</div> <!-- openclose end -->
@@ -33,7 +76,112 @@
 		  <!-- Tier 2 info -->
 		  <div class="tier-2-info item-content">
 		  	<div class="tier-2-info-content">
-		  		Details will go here--------
+					<div class="tier-content">
+		        <div class="row-fluid wrap-row">
+		          <div class="span6" {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({instance : el.data("model") }) }}>
+		            <h6>Status</h6> <!-- else block is not working -->
+		            {{#if_helpers '\
+									^if' allow_mapping_or_creating '\
+									or ^is_allowed' 'update' instance '\
+									or #if' responses.length '\
+									' _1_context=instance.context.id}}
+		              {{instance.status}}
+		            {{else}}
+		              <select class="input-block-level" name="status">
+		                {{#iterate 'Planned' 'In Progress' 'Manager Review' 'Ready for External Review' 'Completed'}}
+		                <option {{#if_equals iterator instance.status}}selected="true"{{/if_equals}}>{{iterator}}</option>
+		                {{/iterate}}
+		              </select>
+		            {{/if_helpers}}
+
+		          </div>
+		        </div>
+
+		        {{#instance.description}}
+		          <div class="row-fluid wrap-row">
+		            <div class="span12">
+		              <h6>Description</h6>
+		              <div class="rtf-block">
+		                {{{instance.description}}}
+		              </div>
+		            </div>
+		          </div>
+		        {{/instance.description}}
+
+		        <div class="row-fluid wrap-row">
+		          <div class="span4">
+		            <h6>Planned Start Date</h6>
+		            {{#if instance.start_date}}
+		              {{localize_date instance.start_date}}
+		            {{else}}
+		              Not set
+		            {{/if}}
+		          </div>
+		          <div class="span4">
+		            <h6>Planned End Date</h6>
+		            {{#if instance.end_date}}
+		              {{localize_date instance.end_date}}
+		            {{else}}
+		              Not set
+		            {{/if}}
+		          </div>
+		          <div class="span4">
+		            <h6>Planned Report Period</h6>
+		            {{#if instance.report_start_date}}
+		              {{#if instance.report_end_date}}
+		                {{localize_date instance.report_start_date}} - {{localize_date instance.report_end_date}}
+		              {{else}}
+		                Starts {{localize_date instance.report_start_date}}
+		              {{/if}}
+		            {{else}}
+		              {{#if instance.report_end_date}}
+		                Ends {{localize_date instance.report_end_date}}
+		              {{else}}
+		                Not set
+		              {{/if}}
+		            {{/if}}
+		          </div>
+		        </div>
+
+		        <div class="row-fluid wrap-row">
+		          <div class="span4">
+		            <h6>Audit Lead</h6>
+		            {{#if instance.contact}}
+		              {{#using contact=instance.contact}}
+		                {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
+		              {{/using}}
+		            {{else}}
+		              Not defined
+		            {{/if}}
+		          </div>
+		          <div class="span4">
+		            <h6>Audit Firm</h6>
+		            {{#using firm=instance.audit_firm}}
+		              {{{firstnonempty firm.title 'None'}}}
+		            {{/using}}
+		          </div>
+		          <div class="span4">
+		            {{! `with_auditors` requires `authorizations` mapping, so preload it }}
+		            {{#with_mapping 'auditor_authorizations' instance}}
+		              {{#if auditor_authorizations.length}}
+		                <h6>{{#if_equals auditor_authorizations.length 1}}Auditor{{else}}Auditors{{/if_equals}}</h6>
+		                <ul class="inner-count-list">
+		                  {{#each auditor_authorizations}}
+		                    <li>
+		                      {{#using auditor=instance.person}}
+		                        {{{renderLive '/static/mustache/people/popover.mustache' person=auditor}}}
+		                      {{/using}}
+		                    </li>
+		                  {{/each}}
+		                </ul>
+		              {{else}}
+		                <h6>Auditors</h6>
+		                No auditor assigned
+		              {{/if}}
+		            {{/with_mapping}}
+		          </div>
+		        </div>
+		      </div>
 		  	</div>	
 		  </div> <!-- tier-2-info -->
 		</li>

--- a/src/ggrc/assets/mustache/dashboard/info/my_audits.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/my_audits.mustache
@@ -1,0 +1,41 @@
+{{!
+    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: sasmita
+    Maintained By: sasmita
+}}
+
+<ul class="tree-structure new-tree dashboard-tree audit-tree">
+	{{#each list}}
+	{{log "Sasmita---------------"}}{{log this}}
+		<li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
+			<div class="item-main" data-model="true" {{#instance}}{{data 'model'}}{{/instance}}>
+				<div class="item-wrap">
+					<div class="openclose">
+		  		<!--/div>
+      		<div class="select"--> <!-- Fix in css- this puts the data in 2 lines -->
+      			<div class="item-data">
+          		<div class="row-fluid">
+          			<span class="status-label status-{{to_class instance.status '_'}}"></span>
+        				<!--i class="grcicon-arrow-right"></i-->
+        				<div class="span4">
+		              <div class="title tree-title-area">
+		                {{instance.title}}
+		              </div>
+		            </div>
+								
+							</div> <!-- row-fluid end -->
+						</div> <!-- item-data end -->
+					</div> <!-- openclose end -->
+				</div> <!-- item-wrap end -->
+		  </div> <!-- item-main end -->
+
+		  <!-- Tier 2 info -->
+		  <div class="tier-2-info item-content">
+		  	<div class="tier-2-info-content">
+		  		Details will go here--------
+		  	</div>	
+		  </div> <!-- tier-2-info -->
+		</li>
+	{{/each}}
+</ul>


### PR DESCRIPTION
This pull request contains:
-New Audit mustache file for new My work page
-First and 2nd layer display
-Tab actions to show/hide both task and audit info
-Initially, only task data is loaded, as user clicks on audit tab, audit data is loaded.