### PR TITLE
Move npm sections to end of tasks main.yml

### DIFF
--- a/provision/roles/ggrc/tasks/main.yml
+++ b/provision/roles/ggrc/tasks/main.yml
@@ -30,24 +30,6 @@
   args:
     chdir: /vagrant
 
-- name: install global npm modules
-  sudo: yes
-  with_items: ggrc_global_npm_modules
-  npm:
-    name: "{{ item.name }}"
-    global: yes
-    state: present
-    registry: http://registry.npmjs.org/
-
-- name: install local npm modules
-  sudo: no
-  with_items: ggrc_local_npm_modules
-  npm:
-    name: "{{ item.name }}"
-    state: present
-    registry: http://registry.npmjs.org/
-    path: "/vagrant/node_modules"
-
 - name: install gems
   sudo: yes
   with_items: ggrc_gems
@@ -85,3 +67,21 @@
     dest: /home/vagrant/.bashrc
     owner: vagrant
     group: vagrant
+
+- name: install global npm modules
+  sudo: yes
+  with_items: ggrc_global_npm_modules
+  npm:
+    name: "{{ item.name }}"
+    global: yes
+    state: present
+    registry: http://registry.npmjs.org/
+
+- name: install local npm modules
+  sudo: no
+  with_items: ggrc_local_npm_modules
+  npm:
+    name: "{{ item.name }}"
+    state: present
+    registry: http://registry.npmjs.org/
+    path: "/vagrant/node_modules"


### PR DESCRIPTION
Installing npm packages fails in certain circumstances (see #2118). Moving these sections to the end prevents aborting subsequent provisioning operations.

I've tested this on Windows and provisioning worked well, right up before failing to install npm modules. Since those were at the end anyway, there's no longer a need to comment out the npm sections, and if we figure out what causes the npm install failure, we won't have to uncomment them.

Here's the log.

```
Welcome to your Vagrant-built virtual machine.
Last login: Fri Sep 14 06:23:18 2012 from 10.0.2.2

vagrant@precise64:~$ echo 'localhost ansible_connection=local' >/tmp/local-inventory

vagrant@precise64:~$ sudo apt-get update
Ign http://us.archive.ubuntu.com precise InRelease
[...]
Get:65 http://us.archive.ubuntu.com precise-backports/universe Translation-en [34.4 kB]
Fetched 5,702 kB in 15s (369 kB/s)
Reading package lists... Done

vagrant@precise64:~$ sudo aptitude install python-pip python-all-dev -y
The following NEW packages will be installed:
  libexpat1-dev{a} libpython2.7{a} python-all{a} python-all-dev python-dev{a} python-pip python-pkg-resources{a} python-setuptools{a} python2.7-dev{a}
The following packages will be upgraded:
  libexpat1 python python-minimal python2.7 python2.7-minimal
5 packages upgraded, 9 newly installed, 0 to remove and 173 not upgraded.
Need to get 36.3 MB of archives. After unpacking 45.0 MB will be used.
[...]
Current status: 173 updates [-5].

vagrant@precise64:~$ sudo pip install ansible markupsafe
Downloading/unpacking ansible
  Downloading ansible-1.8.2.tar.gz (754Kb): 754Kb downloaded
  Running setup.py egg_info for package ansible

    no previously-included directories found matching 'lib/ansible/modules/core/.git'
    no previously-included directories found matching 'lib/ansible/modules/extras/.git'
Downloading/unpacking markupsafe
  Downloading MarkupSafe-0.23.tar.gz
  Running setup.py egg_info for package markupsafe

Downloading/unpacking paramiko (from ansible)
  Downloading paramiko-1.15.2.tar.gz (1.2Mb): 1.2Mb downloaded
  Running setup.py egg_info for package paramiko

Downloading/unpacking jinja2 (from ansible)
  Downloading Jinja2-2.7.3.tar.gz (378Kb): 378Kb downloaded
  Running setup.py egg_info for package jinja2

    warning: no files found matching '*' under directory 'custom_fixers'
    warning: no previously-included files matching '*' found under directory 'docs/_build'
    warning: no previously-included files matching '*.pyc' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
Downloading/unpacking PyYAML (from ansible)
  Downloading PyYAML-3.11.tar.gz (248Kb): 248Kb downloaded
  Running setup.py egg_info for package PyYAML

Requirement already satisfied (use --upgrade to upgrade): distribute in /usr/lib/python2.7/dist-packages (from ansible)
Downloading/unpacking pycrypto>=2.6 (from ansible)
  Downloading pycrypto-2.6.1.tar.gz (446Kb): 446Kb downloaded
  Running setup.py egg_info for package pycrypto

Downloading/unpacking ecdsa>=0.11 (from paramiko->ansible)
  Downloading ecdsa-0.11.tar.gz (45Kb): 45Kb downloaded
  Running setup.py egg_info for package ecdsa

Installing collected packages: ansible, markupsafe, paramiko, jinja2, PyYAML, pycrypto, ecdsa
  Running setup.py install for ansible
    changing mode of build/scripts-2.7/ansible from 644 to 755
    changing mode of build/scripts-2.7/ansible-playbook from 644 to 755
    changing mode of build/scripts-2.7/ansible-pull from 644 to 755
    changing mode of build/scripts-2.7/ansible-doc from 644 to 755
    changing mode of build/scripts-2.7/ansible-galaxy from 644 to 755
    changing mode of build/scripts-2.7/ansible-vault from 644 to 755

    no previously-included directories found matching 'lib/ansible/modules/core/.git'
    no previously-included directories found matching 'lib/ansible/modules/extras/.git'
    changing mode of /usr/local/bin/ansible-playbook to 755
    changing mode of /usr/local/bin/ansible-galaxy to 755
    changing mode of /usr/local/bin/ansible-vault to 755
    changing mode of /usr/local/bin/ansible to 755
    changing mode of /usr/local/bin/ansible-doc to 755
    changing mode of /usr/local/bin/ansible-pull to 755
  Running setup.py install for markupsafe

    building 'markupsafe._speedups' extension
    gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c markupsafe/_speedups.c -o build/temp.linux-x86_64-2.7/markupsafe/_speedups.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-2.7/markupsafe/_speedups.o -o build/lib.linux-x86_64-2.7/markupsafe/_speedups.so
  Running setup.py install for paramiko

  Running setup.py install for jinja2

    warning: no files found matching '*' under directory 'custom_fixers'
    warning: no previously-included files matching '*' found under directory 'docs/_build'
    warning: no previously-included files matching '*.pyc' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
  Running setup.py install for PyYAML
    checking if libyaml is compilable
    gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/check_libyaml.c -o build/temp.linux-x86_64-2.7/check_libyaml.o
    build/temp.linux-x86_64-2.7/check_libyaml.c:2:18: fatal error: yaml.h: No such file or directory
    compilation terminated.

    libyaml is not found or a compiler error: forcing --without-libyaml
    (if libyaml is installed correctly, you may need to
     specify the option --include-dirs or uncomment and
     modify the parameter include_dirs in setup.cfg)

  Running setup.py install for pycrypto
[...]
    configure: creating ./config.status
    config.status: creating src/config.h
    warning: GMP or MPIR library not found; Not building Crypto.PublicKey._fastmath.
    building 'Crypto.Hash._MD2' extension
    gcc [...]

  Running setup.py install for ecdsa

Successfully installed ansible markupsafe paramiko jinja2 PyYAML pycrypto ecdsa
Cleaning up...

vagrant@precise64:~$ sudo ansible-playbook -i /tmp/local-inventory /vagrant/provision/site.yml

PLAY [Reciprocity gGRC] *******************************************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [add the node.js PPA] ***************************************************
changed: [localhost]

TASK: [update apt] ************************************************************
ok: [localhost]

TASK: [common | install common packages] **************************************
changed: [localhost] => (item={'name': 'curl'})
changed: [localhost] => (item={'name': 'git-core'})
ok: [localhost] => (item={'name': 'python-pip'})

TASK: [mysql | install mysql] *************************************************
changed: [localhost]

TASK: [ggrc | install requirements] *******************************************
changed: [localhost]

TASK: [ggrc | install packages] ***********************************************
changed: [localhost] => (item={'name': 'unzip'})
changed: [localhost] => (item={'name': 'zip'})
changed: [localhost] => (item={'name': 'make'})
changed: [localhost] => (item={'name': 'python-virtualenv'})
changed: [localhost] => (item={'name': 'fabric'})
changed: [localhost] => (item={'name': 'python-mysqldb'})
changed: [localhost] => (item={'name': 'python-imaging'})
changed: [localhost] => (item={'name': 'sqlite3'})
ok: [localhost] => (item={'name': 'python-dev'})
changed: [localhost] => (item={'name': 'rubygems'})
changed: [localhost] => (item={'name': 'nodejs'})

TASK: [ggrc | create development directories] *********************************
changed: [localhost] => (item={'name': '/vagrant-dev'})
changed: [localhost] => (item={'name': '/vagrant-dev/opt'})
changed: [localhost] => (item={'name': '/vagrant-dev/tmp'})
ok: [localhost] => (item={'name': '/vagrant/tmp'})

TASK: [ggrc | prepare development virtualenv] *********************************
changed: [localhost]

TASK: [ggrc | install gems] ***************************************************
changed: [localhost] => (item={'name': 'sass'})
changed: [localhost] => (item={'name': 'compass'})

TASK: [ggrc | run make] *******************************************************
changed: [localhost]

TASK: [ggrc | change root password] *******************************************
changed: [localhost]

TASK: [ggrc | create databases] ***********************************************
changed: [localhost] => (item={'name': 'ggrcdev'})
changed: [localhost] => (item={'name': 'ggrctest'})

TASK: [ggrc | configure bash] *************************************************
changed: [localhost]

TASK: [ggrc | install global npm modules] *************************************
changed: [localhost] => (item={'name': 'nodeunit'})
changed: [localhost] => (item={'name': 'pegjs'})
changed: [localhost] => (item={'name': 'karma-cli'})
changed: [localhost] => (item={'name': 'jasmine-core'})
changed: [localhost] => (item={'name': 'mkdirp'})

TASK: [ggrc | install local npm modules] **************************************
failed: [localhost] => (item={'name': 'karma'}) => {"cmd": "/usr/bin/npm install karma --registry http://registry.npmjs.org/", "failed": true, "item": {"name": "karma"}, "rc": 255}
stderr: npm WARN optional dep failed, continuing fsevents@0.3.5
npm ERR! Error: UNKNOWN, symlink '../rimraf/bin.js'
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Linux 3.2.0-23-generic
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "install" "karma" "--registry" "http://registry.npmjs.org/"
npm ERR! cwd /vagrant/node_modules
npm ERR! node -v v0.10.33
npm ERR! npm -v 1.4.28
npm ERR! path ../rimraf/bin.js
npm ERR! code UNKNOWN
npm ERR! errno -1
npm ERR! not ok code 0

msg: npm WARN optional dep failed, continuing fsevents@0.3.5
npm ERR! Error: UNKNOWN, symlink '../rimraf/bin.js'
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Linux 3.2.0-23-generic
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "install" "karma" "--registry" "http://registry.npmjs.org/"
npm ERR! cwd /vagrant/node_modules
npm ERR! node -v v0.10.33
npm ERR! npm -v 1.4.28
npm ERR! path ../rimraf/bin.js
npm ERR! code UNKNOWN
npm ERR! errno -1
npm ERR! not ok code 0
ok: [localhost] => (item={'name': 'karma-jasmine'})

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/home/vagrant/site.retry

localhost                  : ok=15   changed=13   unreachable=0    failed=1

vagrant@precise64:~$ npm install nodeunit pegjs mkdirp jasmine-core karma karma-cli karma-jasmine
npm WARN optional dep failed, continuing fsevents@0.3.5

> ws@0.4.32 install /home/vagrant/node_modules/karma/node_modules/socket.io/node_modules/socket.io-client/node_modules/ws
> (node-gyp rebuild 2> builderror.log) || (exit 0)

make: Entering directory `/home/vagrant/node_modules/karma/node_modules/socket.io/node_modules/socket.io-client/node_modules/ws/build'
  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node: Finished
  COPY Release/bufferutil.node
  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/obj.target/validation.node
  SOLINK_MODULE(target) Release/obj.target/validation.node: Finished
  COPY Release/validation.node
make: Leaving directory `/home/vagrant/node_modules/karma/node_modules/socket.io/node_modules/socket.io-client/node_modules/ws/build'
karma-jasmine@0.3.5 node_modules/karma-jasmine

mkdirp@0.5.0 node_modules/mkdirp
└── minimist@0.0.8

pegjs@0.8.0 node_modules/pegjs

karma-cli@0.0.4 node_modules/karma-cli
└── resolve@0.5.1

jasmine-core@2.1.3 node_modules/jasmine-core

nodeunit@0.9.0 node_modules/nodeunit
└── tap@0.5.0 (yamlish@0.0.6, deep-equal@0.0.0, inherits@2.0.1, buffer-equal@0.0.1, slide@1.1.6, nopt@2.2.1, glob@3.2.11, difflet@0.2.6, runforcover@0.0.2)

karma@0.12.31 node_modules/karma
├── di@0.0.1
├── graceful-fs@2.0.3
├── rimraf@2.2.8
├── colors@0.6.2
├── mime@1.2.11
├── q@0.9.7
├── minimatch@0.2.14 (sigmund@1.0.0, lru-cache@2.5.0)
├── optimist@0.6.1 (wordwrap@0.0.2, minimist@0.0.10)
├── source-map@0.1.43 (amdefine@0.1.0)
├── glob@3.2.11 (inherits@2.0.1, minimatch@0.3.0)
├── chokidar@1.0.0-rc3 (async-each@0.1.6, is-binary-path@1.0.0, glob-parent@1.0.0, anymatch@1.1.0, readdirp@1.3.0)
├── log4js@0.6.22 (semver@1.1.4, async@0.2.10, readable-stream@1.0.33)
├── http-proxy@0.10.4 (pkginfo@0.3.0, utile@0.2.1)
├── lodash@2.4.1
├── connect@2.26.6 (fresh@0.2.4, cookie@0.1.2, pause@0.0.1, cookie-signature@1.0.5, response-time@2.0.1, vhost@3.0.0, on-headers@1.0.0, basic-auth-connect@1.0.0, media-typer@0.3.0, bytes@1.0.0, parseurl@1.3.0, cookie-parser@1.3.3, depd@0.4.5, qs@2.2.4, connect-timeout@1.3.0, finalhandler@0.2.0, debug@2.0.0, method-override@2.2.0, morgan@1.3.2, serve-favicon@2.1.7, csurf@1.6.5, multiparty@3.3.2, serve-static@1.6.4, express-session@1.8.2, body-parser@1.8.4, errorhandler@1.2.4, type-is@1.5.6, serve-index@1.2.1, compression@1.1.2)
├── useragent@2.0.10 (lru-cache@2.2.4)
└── socket.io@0.9.16 (base64id@0.1.0, policyfile@0.0.4, redis@0.7.3, socket.io-client@0.9.16)
vagrant@precise64:~$ logout
```

