### PR TITLE
Feature/object approval object page buttons

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1792,7 +1792,7 @@ Mustache.registerHelper("current_user_is_contact", function (instance, options) 
 
 Mustache.registerHelper("current_user_is_object_reviewer", function (instance, options) {
   instance = Mustache.resolve(instance);
-  var finish = function() {
+  var finish = function(current_object_review_tasks) {
     console.log('finishing');
     var current_user_id = GGRC.current_user.id;
     var contact = instance.contact;

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1790,6 +1790,28 @@ Mustache.registerHelper("current_user_is_contact", function (instance, options) 
   }
 });
 
+Mustache.registerHelper("current_user_is_object_reviewer", function (instance, options) {
+  instance = Mustache.resolve(instance);
+  var finish = function() {
+    console.log('finishing');
+    var current_user_id = GGRC.current_user.id;
+    var contact = instance.contact;
+    for(i = 0; i < current_object_review_tasks.length; i++) {
+      var _task = current_object_review_tasks[i].instance;
+      if (current_user_id == _task.contact.id) {
+        return options.fn(options.contexts);
+      }
+    }
+    return options.inverse(options.contexts);
+  };
+
+  return defer_render(
+    "div",
+    finish,
+    instance.get_binding('current_object_review_tasks').refresh_instances()
+  );
+});
+
 Mustache.registerHelper("default_audit_title", function (instance, options) {
   var program, default_title, current_title
     , index = 1

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1790,16 +1790,18 @@ Mustache.registerHelper("current_user_is_contact", function (instance, options) 
   }
 });
 
-Mustache.registerHelper("current_user_is_object_reviewer", function (options) {
+Mustache.registerHelper("with_is_reviewer", function (options) {
   var tasks = options.context['current_object_review_tasks'];
   var current_user_id = GGRC.current_user.id;
   tasks = Mustache.resolve(tasks);
   for(i = 0; i < tasks.length; i++) {
     if (current_user_id == tasks[i].instance.contact.id) {
-      return options.fn(options.contexts);
+    // NOTE: Note that the review_task is set into the context here as well.
+    }
+      return options.fn(options.contexts.add({is_reviewer: true, review_task: tasks[i].instance}));
     }
   }
-  return options.inverse(options.contexts);
+  return options.fn(options.contexts);
 });
 
 Mustache.registerHelper("default_audit_title", function (instance, options) {

--- a/src/ggrc/assets/mustache/people/popover.mustache
+++ b/src/ggrc/assets/mustache/people/popover.mustache
@@ -15,7 +15,7 @@
     <a href="/people/{{id}}"><span class="person-tooltip-trigger" data-placement="top">
       {{firstnonempty name email}}
     </span></a>
-  {{/show_email}}
+  {{/if}}
   <div class="custom-popover-content">
     <div class="preview-container person-preview">
       <div class="row-fluid">

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -296,6 +296,17 @@
           return binding.instance.attr("object_approval");
         });
       mappings[type].current_approval_cycles = Cross("approval_workflows", "current_cycle");
+      mappings[type].current_object_review_tasks = CustomFilter(
+        "object_tasks", function(binding) {
+        return RefreshQueue().enqueue(
+            binding.instance.attr("task_group_task").reify()
+          ).trigger().then(
+            function(data){
+              var tgt = data[0];
+              return tgt.attr("object_approval");
+            }
+          )
+        });
       mappings[type]._canonical = {
        "workflows": "Workflow",
        "task_groups": "TaskGroup"

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -298,7 +298,7 @@
       mappings[type].current_approval_cycles = Cross("approval_workflows", "current_cycle");
       mappings[type].current_object_review_tasks = CustomFilter(
         "object_tasks", function(binding) {
-        return RefreshQueue().enqueue(
+        return new RefreshQueue().enqueue(
             binding.instance.attr("task_group_task").reify()
           ).trigger().then(
             function(data){

--- a/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
@@ -4,19 +4,34 @@
     <span class="object-approved">Reviewed and approved</span>
   {{else}}
     {{#if_helpers '\
-      #owned_by_current_user' instance '\
-      or #current_user_is_admin'}}
+      #current_user_is_object_reviewer' instance}}
       {{#with_mapping_count instance 'current_approval_cycles'}}
-        {{#if_equals count 0}}
-          <a href="javascript://" class="non-transparent" data-toggle="modal-ajax-approvalform" data-object-singular="{{model.model_singular}}" data-object-id="page">
-            <i class="grcicon-review"></i>
-            Submit For Review
-          </a>
+        {{^if_equals count 0}}
+          <div class="request-control">
+            <button class="btn btn-success change-task-status {{instance._disabled}}" data-name="status" data-value="Verified">Approve</button>
+            <button class="btn btn-danger change-task-status {{instance._disabled}}" data-name="status" data-value="Declined">Decline</button>
+          </div>
         {{else}}
-          <i class="grcicon-review"></i>
-          <span class="setup-link">Review in progress</span>
+          <div>No current approval cycles.</div>
         {{/if_equals}}
       {{/with_mapping_count}}
+    {{else}}
+      <p>User is not object reviewer.</p>
+      {{#if_helpers '\
+        #owned_by_current_user' instance '\
+        or #current_user_is_admin'}}
+        {{#with_mapping_count instance 'current_approval_cycles'}}
+          {{#if_equals count 0}}
+            <a href="javascript://" class="non-transparent" data-toggle="modal-ajax-approvalform" data-object-singular="{{model.model_singular}}" data-object-id="page">
+              <i class="grcicon-review"></i>
+              Submit For Review
+            </a>
+          {{else}}
+            <i class="grcicon-review"></i>
+            <span class="setup-link">Review in progress</span>
+          {{/if_equals}}
+        {{/with_mapping_count}}
+      {{/if_helpers}}
     {{/if_helpers}}
   {{/if_equals}}
 </li>

--- a/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
@@ -5,30 +5,31 @@
     <span class="object-approved">Reviewed and approved</span>
   {{else}}
     {{#with_mapping 'current_object_review_tasks' instance}}
-      {{#current_user_is_object_reviewer}}
-        <div class="request-control" {{ (el) -> $(el).bind('inserted', function() { el.ggrc_controllers_quick_form({ instance : el.closest('li').data('model')}); }); }}>
-          <span class="setup-link">Approval applies only to this object and not to mapped objects.</span>
-          <button class="btn btn-success change-task-status {{instance._disabled}}" data-name="status" data-value="Verified">Approve</button>
-          <button class="btn btn-danger change-task-status {{instance._disabled}}" data-name="status" data-value="Declined">Decline</button>
-        </div>
-      {{/current_user_is_object_reviewer}}
-      {{^current_user_is_object_reviewer}}
-        {{#if_helpers '\
-          #owned_by_current_user' instance '\
-          or #current_user_is_admin'}}
-          {{#with_mapping_count instance 'current_approval_cycles'}}
-            {{#if_equals count 0}}
-              <a href="javascript://" class="non-transparent" data-toggle="modal-ajax-approvalform" data-object-singular="{{model.model_singular}}" data-object-id="page">
+      {{#with_is_reviewer}}
+        {{#if is_reviewer}}
+          <div class="" {{#review_task}}{{data 'model'}}{{/review_task}} {{ (el) -> el.ggrc_controllers_quick_form({instance : el.data("model") }) }}>
+            <span class="setup-link">Approval applies only to this object and not to mapped objects.</span>
+            <button class="btn btn-success change-task-status {{instance._disabled}}" data-name="status" data-value="Verified">Approve</button>
+            <button class="btn btn-danger change-task-status {{instance._disabled}}" data-name="status" data-value="Declined">Decline</button>
+          </div>
+        {{else}}
+          {{#if_helpers '\
+            #owned_by_current_user' instance '\
+            or #current_user_is_admin'}}
+            {{#with_mapping_count instance 'current_approval_cycles'}}
+              {{#if_equals count 0}}
+                <a href="javascript://" class="non-transparent" data-toggle="modal-ajax-approvalform" data-object-singular="{{model.model_singular}}" data-object-id="page">
+                  <i class="grcicon-review"></i>
+                  Submit For Review
+                </a>
+              {{else}}
                 <i class="grcicon-review"></i>
-                Submit For Review
-              </a>
-            {{else}}
-              <i class="grcicon-review"></i>
-              <span class="setup-link">Review in progress</span>
-            {{/if_equals}}
-          {{/with_mapping_count}}
-        {{/if_helpers}}
-      {{/current_user_is_object_reviewer}}
+                <span class="setup-link">Review in progress</span>
+              {{/if_equals}}
+            {{/with_mapping_count}}
+          {{/if_helpers}}
+        {{/if}}
+      {{/with_is_reviewer}}
     {{/with_mapping}}
   {{/if_equals}}
 </li>


### PR DESCRIPTION
The logic needs to be:
	If the current user is the contact on the object_review task for the current object, show the buttons.
	Otherwise, if the current user is the object owner or an admin, and the object is not yet submitted
	for review, show "Submit for review" link. Otherwise, show "Review in progress".

I know that the logic isn't quite right in the mustache template. But what I'm working on right now is getting the mustache helper to fire the code defined in the callback function.

I've been told that defer_render is the way to go for this because the mapping to get the object review task must be resolved/refreshed asynchronously.

**I'm looking for help on why the callback function isn't firing and how to correct it.**