### PR TITLE
phantomjs2 will make karma life nicer

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -64,7 +64,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: [/*'PhantomJS'*/],
+    browsers: ['PhantomJS'],
 
     customLaunchers: {
         Chrome_travis_ci: {

--- a/provision/roles/ggrc/vars/main.yml
+++ b/provision/roles/ggrc/vars/main.yml
@@ -29,10 +29,12 @@ ggrc_global_npm_modules:
   - name: karma-cli
   - name: jasmine-core
   - name: mkdirp
+  - name: phantomjs
 
 ggrc_local_npm_modules:
   - name: karma
   - name: karma-jasmine
+  - name: karma-phantomjs-launcher
 
 ggrc_gems:
   - name: sass


### PR DESCRIPTION
PhantomJS v2 was released last week. This version will support our code and as such is going to make running karma tests nicer locally because you won't have to have a Chrome open.

However, the npm package hasn't blessed v2 yet -> https://github.com/Medium/phantomjs/issues/288

This PR is here so that this does not slip my mind. Do not merge yet!