### PR TITLE
horizontal navbar is now nicely sortable

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -372,13 +372,9 @@ can.Control("CMS.Controllers.InnerNav", {
       CMS.Models.DisplayPrefs.getSingleton().then(function (prefs) {        
         this.display_prefs = prefs;
 
-        console.log(typeof this.options.widget_list, this.options.widget_list);
-
         if (!this.options.widget_list) {
           this.options.widget_list = new can.Observe.List([]);
         }
-
-        console.log(this.options.widget_list.serialize());
 
         this.options.instance = GGRC.page_instance();
 
@@ -562,6 +558,8 @@ can.Control("CMS.Controllers.InnerNav", {
         , existing_index
         ;
 
+      index = this.saved_widget_index($widget, index);
+
       if(this.delayed_display) {
         clearTimeout(this.delayed_display.timeout);
         this.delayed_display.timeout = setTimeout(this.delayed_display.fn, 50);
@@ -610,6 +608,21 @@ can.Control("CMS.Controllers.InnerNav", {
         }
       }
       return widget;
+  }
+
+  , saved_widget_index: function ($widget, index) {
+    var widgets = this.display_prefs.getTopNavWidgets(window.getPageToken()),
+        id = $widget.attr("id");
+
+    if (widgets[id]) {
+      index = widgets[id];
+    }else{
+      widgets[id] = index;
+      this.display_prefs.setTopNavWidgets(window.getPageToken(), widgets);
+      this.display_prefs.save();
+    }
+
+    return index;
   }
 
   , update_widget_count : function($el, count) {

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -95,7 +95,7 @@ can.Control("CMS.Controllers.Dashboard", {
             });
       }
 
-      if (this.display_prefs.getNavHidden()) {
+      if (this.display_prefs.getTopNavHidden()) {
         // page needs time to render
         setTimeout(this.close_nav.bind(this), 500);
       }
@@ -129,7 +129,7 @@ can.Control("CMS.Controllers.Dashboard", {
     $nav.animate({top: "96"}, options);
     $fake_merge.animate({top: "136"}, options);
 
-    this.display_prefs.setNavHidden("", false);
+    this.display_prefs.setTopNavHidden("", false);
     $(window).trigger("resize");
   }
 
@@ -150,7 +150,7 @@ can.Control("CMS.Controllers.Dashboard", {
     $nav.animate({top: "66"}, options);
     $fake_merge.animate({top: "106"}, options);
 
-    this.display_prefs.setNavHidden("", true);
+    this.display_prefs.setTopNavHidden("", true);
     $(window).trigger("resize");
   }
 
@@ -378,7 +378,7 @@ can.Control("CMS.Controllers.InnerNav", {
           this.options.widget_list = new can.Observe.List([]);
         }
 
-        console.log(this.options.widget_list);
+        console.log(this.options.widget_list.serialize());
 
         this.options.instance = GGRC.page_instance();
 

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -465,12 +465,19 @@ can.Control("CMS.Controllers.InnerNav", {
   , " sortupdate": "apply_widget_list_sort"
 
   , apply_widget_list_sort: function() {
-      var widget_ids
-        ;
+      var widget_ids,
+          indexes = this.display_prefs.getTopNavWidgets(window.getPageToken());
 
       widget_ids = this.element.find("li > a").map(function() {
         return $(this).attr("href");
       }).toArray();
+
+      widget_ids.forEach(function (id, index) {
+        indexes[id.replace("#", "")] = index;
+      });
+
+      this.display_prefs.setTopNavWidgets(window.getPageToken());
+      this.display_prefs.save();
 
       this.element.trigger("inner_nav_sort_updated", [widget_ids]);
     }

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -464,9 +464,10 @@ can.Control("CMS.Controllers.InnerNav", {
 
   , " sortupdate": "apply_widget_list_sort"
 
-  , apply_widget_list_sort: function() {
+  , apply_widget_list_sort: function(container, event, target) {
       var widget_ids,
-          indexes = this.display_prefs.getTopNavWidgets(window.getPageToken());
+          indexes = this.display_prefs.getTopNavWidgets(window.getPageToken()),
+          widget = target.item.find("a").attr("href");
 
       widget_ids = this.element.find("li > a").map(function() {
         return $(this).attr("href");
@@ -478,6 +479,13 @@ can.Control("CMS.Controllers.InnerNav", {
 
       this.display_prefs.setTopNavWidgets(window.getPageToken());
       this.display_prefs.save();
+
+      // for some reason the .parent().addClass doesn't work without timeout
+      if ($(target.item).hasClass("active")) {
+        setTimeout(function () {
+          this.element.find("li > a[href='"+widget+"']").parent().addClass("active");
+        }.bind(this), 0);
+      }
 
       this.element.trigger("inner_nav_sort_updated", [widget_ids]);
     }

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -369,37 +369,45 @@ can.Control("CMS.Controllers.InnerNav", {
   }
 }, {
     init: function(options) {
-      var that = this
-        ;
+      CMS.Models.DisplayPrefs.getSingleton().then(function (prefs) {        
+        this.display_prefs = prefs;
 
-      if (!this.options.widget_list)
-        this.options.widget_list = new can.Observe.List([]);
+        console.log(typeof this.options.widget_list, this.options.widget_list);
 
-      this.options.instance = GGRC.page_instance();
-
-      this.sortable();
-
-      if (!(this.options.contexts instanceof can.Observe))
-        this.options.contexts = new can.Observe(this.options.contexts);
-
-      // FIXME: Initialize from `*_widget` hash when hash has no `#!`
-      can.bind.call(window, 'hashchange', function() {
-        that.route(window.location.hash);
-      });
-
-      can.view(this.options.internav_view, this.options, function(frag) {
-        function fn() {
-          that.element.append(frag);
-          that.route(window.location.hash);
-          delete that.delayed_display;
+        if (!this.options.widget_list) {
+          this.options.widget_list = new can.Observe.List([]);
         }
-        that.delayed_display = {
-          fn : fn
-          , timeout : setTimeout(fn, 50)
-        };
-      });
 
-      this.on();
+        console.log(this.options.widget_list);
+
+        this.options.instance = GGRC.page_instance();
+
+        this.sortable();
+
+        if (!(this.options.contexts instanceof can.Observe)) {
+         this.options.contexts = new can.Observe(this.options.contexts);
+        }
+
+        // FIXME: Initialize from `*_widget` hash when hash has no `#!`
+        can.bind.call(window, 'hashchange', function() {
+          this.route(window.location.hash);
+        }.bind(this));
+
+        can.view(this.options.internav_view, this.options, function(frag) {
+          var fn = function () {
+            this.element.append(frag);
+            this.route(window.location.hash);
+            delete this.delayed_display;
+          }.bind(this);
+
+          this.delayed_display = {
+            fn : fn
+            , timeout : setTimeout(fn, 50)
+          };
+        }.bind(this));
+
+        this.on();
+      }.bind(this));
     }
 
   , route: function(path) {
@@ -424,7 +432,7 @@ can.Control("CMS.Controllers.InnerNav", {
           widget_list = this.options.widget_list;
 
       // Find and make active the widget specified by `step`
-      widget = this.find_widget_by_target("#" + step);
+      var widget = this.find_widget_by_target("#" + step);
       if (!widget && widget_list.length) {
         // Target was not found, but we can select the first widget in the list
         widget = widget_list[0];

--- a/src/ggrc/assets/javascripts/models/display_prefs.js
+++ b/src/ggrc/assets/javascripts/models/display_prefs.js
@@ -19,7 +19,7 @@ var COLLAPSE = "collapse"
 , PBC_LISTS = "pbc_lists"
 , GLOBAL = "global"
 , LHN_STATE = "lhn_state"
-, NAV_HIDDEN = "nav_hidden"
+, TOP_NAV = "top_nav"
 , path = window.location.pathname.replace(/\./g, "/");
 
 can.Model.LocalStorage("CMS.Models.DisplayPrefs", {
@@ -129,18 +129,18 @@ can.Model.LocalStorage("CMS.Models.DisplayPrefs", {
     return widget_id ? collapsed.attr(widget_id) : collapsed;
   }
 
-  , setNavHidden: function (page_id, is_hidden) {
-    this.makeObject(page_id === null ? page_id : path, NAV_HIDDEN).attr("is_hidden", !!is_hidden);
+  , setTopNavHidden: function (page_id, is_hidden) {
+    this.makeObject(page_id === null ? page_id : path, TOP_NAV).attr("is_hidden", !!is_hidden);
     
     this.autoupdate && this.save();
     return this;
   }
 
-  , getNavHidden: function (page_id) {
-    var value = this.getObject(page_id === null ? page_id : path, NAV_HIDDEN);
+  , getTopNavHidden: function (page_id) {
+    var value = this.getObject(page_id === null ? page_id : path, TOP_NAV);
 
     if (typeof value === "undefined") {
-      this.setNavHidden("", false);
+      this.setTopNavHidden("", false);
       return false;
     }
 

--- a/src/ggrc/assets/javascripts/models/display_prefs.js
+++ b/src/ggrc/assets/javascripts/models/display_prefs.js
@@ -158,11 +158,11 @@ can.Model.LocalStorage("CMS.Models.DisplayPrefs", {
     var value = this.getObject(page_id === null ? page_id : path, TOP_NAV);
 
     if (typeof value === "undefined") {
-      this.setTopNavWidgets(page_id, []);
+      this.setTopNavWidgets(page_id, {});
       return this.getTopNavWidgets(page_id);
     }
 
-    return value.widget_list;
+    return value.widget_list && value.widget_list.serialize() || {};
   }
 
   , setLHNavSize : function(page_id, widget_id, size) {

--- a/src/ggrc/assets/javascripts/models/display_prefs.js
+++ b/src/ggrc/assets/javascripts/models/display_prefs.js
@@ -147,6 +147,24 @@ can.Model.LocalStorage("CMS.Models.DisplayPrefs", {
     return !!value.is_hidden;
   }
 
+  , setTopNavWidgets: function (page_id, widget_list) {
+    this.makeObject(page_id === null ? page_id : path, TOP_NAV).attr("widget_list", widget_list);
+
+    this.autoupdate && this.save();
+    return this;
+  }
+
+  , getTopNavWidgets: function (page_id) {
+    var value = this.getObject(page_id === null ? page_id : path, TOP_NAV);
+
+    if (typeof value === "undefined") {
+      this.setTopNavWidgets(page_id, []);
+      return this.getTopNavWidgets(page_id);
+    }
+
+    return value.widget_list;
+  }
+
   , setLHNavSize : function(page_id, widget_id, size) {
     this.makeObject(page_id === null ? page_id : path, LHN_SIZE).attr(widget_id, size);
     this.autoupdate && this.save();

--- a/src/ggrc/assets/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc/assets/js_specs/models/display_prefs_spec.js
@@ -69,30 +69,51 @@ describe("display prefs model", function() {
     });
   });
 
-  describe("top nav hiddenness", function () {
+  describe("top nav", function () {
     afterEach(function() {
       display_prefs.resetPagePrefs();
       //display_prefs.removeAttr(exp.path);
     });
 
-    it("sets nav hidden", function() {
-      display_prefs.setNavHidden("this arg is ignored", true);
+    describe("hiddenness", function () {
+      it("sets nav hidden", function() {
+        display_prefs.setTopNavHidden("this arg is ignored", true);
+            
+        expect(
+          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.is_hidden
+        ).toBe(true);
+      });
+        
+      it("gets nav hidden", function () {
+        display_prefs.setTopNavHidden("this arg is ignored", true);
+            
+        expect(display_prefs.getTopNavHidden()).toBe(true);
+      });
+        
+      it("returns false by default", function () {
+        expect(display_prefs.getTopNavHidden()).toBe(false);
+      });
+    }); 
 
-      expect(
-          display_prefs.attr([exp.path, exp.NAV_HIDDEN].join(".")).nav_hidden.is_hidden
-      ).toBe(true);
+    describe("widget list", function () {
+      it("sets widget list", function () {
+        display_prefs.setTopNavList("this arg is ignored", [1, 2, 3]);
+
+        expect(
+          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.widget_list
+        ).toEqual([1, 2, 3]);
+      });
+        
+      it("gets widget list", function () {
+        display_prefs.setTopNavList("this arg is ignored", [1, 2, 3]);
+
+        expect(display_prefs.getTopNavList()).toEqual([1, 2, 3]);
+      });
+
+      it("returns [] by default", function () {
+        expect(display_prefs.getTopNavList()).toEqual([]);
+      });
     });
-
-    it("gets nav hidden", function () {
-      display_prefs.setNavHidden("this arg is ignored", true);
-
-      expect(display_prefs.getNavHidden()).toBe(true);
-    });
-
-    it("returns false by default", function () {
-      expect(display_prefs.getNavHidden()).toBe(false);
-    });
-
   });
 
   xdescribe("#setCollapsed", function() {

--- a/src/ggrc/assets/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc/assets/js_specs/models/display_prefs_spec.js
@@ -97,21 +97,21 @@ describe("display prefs model", function() {
 
     describe("widget list", function () {
       it("sets widget list", function () {
-        display_prefs.setTopNavList("this arg is ignored", [1, 2, 3]);
+        display_prefs.setTopNavWidgets("this arg is ignored", [1, 2, 3]);
 
         expect(
-          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.widget_list
+          display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.widget_list.serialize()
         ).toEqual([1, 2, 3]);
       });
         
       it("gets widget list", function () {
-        display_prefs.setTopNavList("this arg is ignored", [1, 2, 3]);
+        display_prefs.setTopNavWidgets("this arg is ignored", [1, 2, 3]);
 
-        expect(display_prefs.getTopNavList()).toEqual([1, 2, 3]);
+        expect(display_prefs.getTopNavWidgets().serialize()).toEqual([1, 2, 3]);
       });
 
       it("returns [] by default", function () {
-        expect(display_prefs.getTopNavList()).toEqual([]);
+        expect(display_prefs.getTopNavWidgets().serialize()).toEqual([]);
       });
     });
   });

--- a/src/ggrc/assets/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc/assets/js_specs/models/display_prefs_spec.js
@@ -97,21 +97,21 @@ describe("display prefs model", function() {
 
     describe("widget list", function () {
       it("sets widget list", function () {
-        display_prefs.setTopNavWidgets("this arg is ignored", [1, 2, 3]);
+        display_prefs.setTopNavWidgets("this arg is ignored", {a:1, b: 2});
 
         expect(
           display_prefs.attr([exp.path, exp.TOP_NAV].join(".")).top_nav.widget_list.serialize()
-        ).toEqual([1, 2, 3]);
+        ).toEqual({a: 1, b: 2});
       });
         
       it("gets widget list", function () {
-        display_prefs.setTopNavWidgets("this arg is ignored", [1, 2, 3]);
+        display_prefs.setTopNavWidgets("this arg is ignored", {a: 1, b: 2});
 
-        expect(display_prefs.getTopNavWidgets().serialize()).toEqual([1, 2, 3]);
+        expect(display_prefs.getTopNavWidgets()).toEqual({a: 1, b: 2});
       });
 
-      it("returns [] by default", function () {
-        expect(display_prefs.getTopNavWidgets().serialize()).toEqual([]);
+      it("returns {} by default", function () {
+        expect(display_prefs.getTopNavWidgets()).toEqual({});
       });
     });
   });


### PR DESCRIPTION
@arraystudio wouldn't it make more sense to allow sorting of the navbar, but preserve the order through page refreshes?

(fixes CORE-1081)