### PR TITLE
Partial tests around can.Model Cacheable

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -296,6 +296,7 @@ dashboard-js-spec-files:
   - models/recently_viewed_object_spec.js
   - models/display_prefs_spec.js
   - models/mappers_spec.js
+  - models/cacheable_spec.js
 
 dashboard-js-spec-helpers:
   - jasmine-fixture.js

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -860,7 +860,7 @@ can.Model("can.Model.Cacheable", {
         dfd : new $.Deferred()
         , fn : $.throttle(1000, true, function() {
           var dfd = that._pending_refresh.dfd;
-          $.ajax({
+          can.ajax({
             url : href
             , params : params
             , type : "get"

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -336,19 +336,6 @@ can.Model("can.Model.Cacheable", {
       return ret;
     };
 
-
-    var _refresh = this.makeFindOne({ type : "get", url : "{href}" });
-    this.refresh = function(params) {
-      var that = this,
-          href = params.selfLink || params.href;
-
-      if (href)
-        return _refresh.call(this, {href : params.selfLink || params.href})
-               .done(function(d) { d.backup(); });
-      else
-        return (new can.Deferred()).reject();
-    };
-
     // Register this type as a custom attributable type if it is one.
     if(this.is_custom_attributable) {
       if(!GGRC.custom_attributable_types) {
@@ -862,8 +849,9 @@ can.Model("can.Model.Cacheable", {
     this._triggerChange(attrName, "set", this[attrName], this[attrName].slice(0, this[attrName].length - 1));
   }
   , refresh : function(params) {
-    var href = this.selfLink || this.href
-    , that = this;
+    var dfd,
+      href = this.selfLink || this.href,
+      that = this;
 
     if (!href)
       return (new can.Deferred()).reject();
@@ -893,8 +881,9 @@ can.Model("can.Model.Cacheable", {
         })
       };
     }
+    dfd = this._pending_refresh.dfd
     this._pending_refresh.fn();
-    return this._pending_refresh.dfd;
+    return dfd;
   }
   , serialize : function() {
     var that = this, serial = {};

--- a/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
+++ b/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
@@ -142,7 +142,7 @@ describe('GGRC.query_parser', function() {
           order_by : { keys : [ ], order : '', compare : null },
           keys: ['5words'],
           evaluate: jasmine.any(Function)
-        })
+        });
 
     });
 
@@ -162,7 +162,7 @@ describe('GGRC.query_parser', function() {
           },
           keys: ['5words'],
           evaluate: jasmine.any(Function)
-        })
+        });
 
     });
 

--- a/src/ggrc/assets/js_specs/models/cacheable_spec.js
+++ b/src/ggrc/assets/js_specs/models/cacheable_spec.js
@@ -1,0 +1,225 @@
+/*!
+    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: brad@reciprocitylabs.com
+    Maintained By: brad@reciprocitylabs.com
+*/
+
+describe("can.Model.Cacheable", function() {
+  
+  beforeAll(function() {
+    can.Model.Mixin("dummyable");
+    spyOn(CMS.Models.Mixins.dummyable, "add_to");
+
+    can.Model.Cacheable.extend("CMS.Models.DummyModel", {
+      root_object: "dummy_model",
+      root_collection: "dummy_models",
+      mixins: ["dummyable"],
+      attributes: { dummy_attribute: "dummy_convert" },
+      is_custom_attributable: true
+    }, {});
+  });
+
+  afterAll(function() {
+    delete CMS.Models.DummyModel;
+    delete CMS.Models.Mixins.dummyable;
+  });
+
+  describe("::setup", function() {
+
+    it("prefers pre-set static names over root object & collection", function() {
+      var Model = can.Model.Cacheable.extend({
+        root_object: "wrong_name",
+        root_collection: "wrong_names",
+        model_singular: "RightName",
+        table_singular: "right_name",
+        title_singular: "Right Name",
+        model_plural: "RightNames",
+        table_plural: "right_names",
+        title_plural: "Right Names"
+      }, {});
+      // note that these are not explicit in beforeAll above.
+      // model singular is CamelCased form of root_object
+      expect(Model.model_singular).toBe("RightName");
+      // table singular is under_scored version of same
+      expect(Model.table_singular).toBe("right_name");
+      // title singular is "Human Readable" version of same
+      expect(Model.title_singular).toBe("Right Name");
+      // plurals are based on root collection.
+      expect(Model.model_plural).toBe("RightNames");
+      expect(Model.table_plural).toBe("right_names");
+      expect(Model.title_plural).toBe("Right Names");
+    });
+
+    it("sets various forms of the name based on root object & collection by default", function() {
+      // note that these are not explicit in beforeAll above.
+      // model singular is CamelCased form of root_object
+      expect(CMS.Models.DummyModel.model_singular).toBe("DummyModel");
+      // table singular is under_scored version of same
+      expect(CMS.Models.DummyModel.table_singular).toBe("dummy_model");
+      // title singular is "Human Readable" version of same
+      expect(CMS.Models.DummyModel.title_singular).toBe("Dummy Model");
+      // plurals are based on root collection.
+      expect(CMS.Models.DummyModel.model_plural).toBe("DummyModels");
+      expect(CMS.Models.DummyModel.table_plural).toBe("dummy_models");
+      expect(CMS.Models.DummyModel.title_plural).toBe("Dummy Models");
+    });
+
+    it("sets findAll to default based on root_collection if not set", function() {
+      spyOn(can.Model, "setup");
+      var Model = can.Model.Cacheable.extend({ root_collection: "foos" }, {});
+      expect(Model.findAll).toBe("GET /api/foos");
+    });
+
+    it("applies mixins based on the mixins property", function() {
+      expect(CMS.Models.Mixins.dummyable.add_to).toHaveBeenCalledWith(CMS.Models.DummyModel);
+    });
+
+    it("merges in default attributes for created_at and updated_at", function() {
+      expect(CMS.Models.DummyModel.attributes).toEqual({
+        created_at: "datetime",
+        updated_at: "datetime",
+        dummy_attribute: "dummy_convert"
+      });
+    });
+
+  });
+
+  describe("::init", function() {
+
+    it("sets custom attributes", function() {
+      // NB using $.extend here creates a new object with all of the static properties of the function.
+      //  This is how the custom attributable is implemented in setup.
+      expect(GGRC.custom_attributable_types).toContain($.extend({}, CMS.Models.DummyModel));
+    });
+
+  });
+
+
+  describe("::makeDestroy", function() {
+
+    var destroy_spy;
+    beforeEach(function() {
+      destroy_spy = jasmine.createSpy("destroy");
+      spyOn(CMS.Models.BackgroundTask, "findOne").and.returnValue($.when());
+    });
+
+    it("finds background task if specified in return object", function(done) {
+      var destroy = CMS.Models.DummyModel.makeDestroy(destroy_spy);
+      destroy_spy.and.returnValue($.when({ background_task: {id: 1}}));
+
+      destroy(2).then(function() {
+        expect(CMS.Models.BackgroundTask.findOne).toHaveBeenCalledWith({ id: 1 });
+        done();
+      }, function() {
+        can.each(arguments, function(arg) {
+          fail(JSON.stringify(arg));
+        });
+        done();
+      });
+    });
+
+    it("polls background task if found", function(done) {
+      var destroy = CMS.Models.DummyModel.makeDestroy(destroy_spy);
+      var poll_spy = jasmine.createSpyObj("poll_spy", ["poll"]);
+      destroy_spy.and.returnValue($.when({ background_task: {id: 1}}));
+      CMS.Models.BackgroundTask.findOne.and.returnValue($.when(poll_spy));
+
+      destroy(2).then(function() {
+        expect(CMS.Models.BackgroundTask.findOne).toHaveBeenCalledWith({ id: 1 });
+        expect(poll_spy.poll).toHaveBeenCalled();
+        done();
+      }, function() {
+        can.each(arguments, function(arg) {
+          fail(JSON.stringify(arg));
+        });
+        done();
+      });
+    });
+
+    it("continues normally if no background task specified", function(done) {
+      var destroy = CMS.Models.DummyModel.makeDestroy(destroy_spy);
+      destroy_spy.and.returnValue($.when({ dummy: {id: 1}}));
+
+      destroy(2).then(function() {
+        expect(CMS.Models.BackgroundTask.findOne).not.toHaveBeenCalled();
+        done();
+      }, function() {
+        can.each(arguments, function(arg) {
+          fail(JSON.stringify(arg));
+        });
+        done();
+      });
+    });
+
+  });
+
+  describe("::findAll", function() {
+
+    it("throws errors when called directly on Cacheable instead of a subclass", function() {
+      expect(can.Model.Cacheable.findAll).toThrow(
+        "No default findAll() exists for subclasses of Cacheable"
+      );
+    });
+  });
+
+  describe("::findPage", function() {
+    it("throws errors when called directly on Cacheable instead of a subclass", function() {
+      expect(can.Model.Cacheable.findPage).toThrow(
+       "No default findPage() exists for subclasses of Cacheable"
+      );
+    });
+  
+  });
+
+  describe("#refresh", function() {
+
+    var inst;
+    beforeEach(function() {
+      inst = new CMS.Models.DummyModel({ href : '/api/dummy_models/1' });
+      spyOn($, "ajax").and.returnValue(new $.Deferred(function(dfd) {
+        setTimeout(function() {
+          dfd.resolve(inst.serialize());
+        }, 10);
+      }));
+    });
+    afterEach(function() {
+      delete CMS.Models.DummyModel.cache[undefined];
+    });
+
+    it("calls the object endpoint with the supplied href if no selfLink", function(done) {
+      inst.refresh().then(function() {
+        expect($.ajax).toHaveBeenCalledWith(jasmine.objectContaining({
+          url: "/api/dummy_models/1",
+          type: "get"
+        }));
+        done();
+      }, fail);
+    });
+
+    it("throttles the requests to once per second", function(done) {
+      inst.refresh();
+      inst.refresh();
+      setTimeout(function() {
+        inst.refresh().then(function() {
+          expect($.ajax.calls.count()).toBe(2);
+          done();
+        }, fail);
+      }, 1000); // 1000ms is enough to trigger a new call to the debounced function
+      inst.refresh().then(function() {
+        expect($.ajax.calls.count()).toBe(1);
+      }, fail);
+    });
+
+    it("backs up the refreshed state immediately after refreshing", function(done) {
+      spyOn(CMS.Models.DummyModel, "model").and.returnValue(inst);
+      spyOn(inst, "backup");
+      inst.refresh().then(function() {
+        expect(inst.backup).toHaveBeenCalled();
+        done();
+      }, fail);
+    });
+  });
+
+
+});

--- a/src/ggrc/assets/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc/assets/js_specs/models/display_prefs_spec.js
@@ -9,8 +9,8 @@
 describe("display prefs model", function() {
   
   var display_prefs, exp;
-  beforeEach(function() {
-    display_prefs || (display_prefs = new CMS.Models.DisplayPrefs());
+  beforeAll(function() {
+    display_prefs = new CMS.Models.DisplayPrefs();
     exp = CMS.Models.DisplayPrefs.exports;
   });
 
@@ -65,7 +65,7 @@ describe("display prefs model", function() {
 
       it("returns undefined when the key is not found", function(){
         expect(display_prefs.getObject("xyzzy")).not.toBeDefined();
-      })
+      });
     });
   });
 
@@ -95,7 +95,7 @@ describe("display prefs model", function() {
 
   });
 
-  xdescribe("#setCollapsed", function() {
+  describe("#setCollapsed", function() {
     afterEach(function() {
       display_prefs.removeAttr(exp.COLLAPSE);
       display_prefs.removeAttr(exp.path);
@@ -106,10 +106,6 @@ describe("display prefs model", function() {
 
       expect(display_prefs.attr([exp.path, exp.COLLAPSE, "foo"].join("."))).toBe(true);
     });
-
-    xit("sets all collapse values as a collection", function() {
-      //TODO: this feature isn't currently supported for collapse
-    });
   });
 
   function getSpecs (func, token, fooValue, barValue) {
@@ -118,11 +114,11 @@ describe("display prefs model", function() {
 
     return function() {
       function getTest() {
-          var fooActual = display_prefs[func]("unit_test", "foo");
-          var barActual = display_prefs[func]("unit_test", "bar");
-         
-          expect(fooActual.serialize ? fooActual.serialize() : fooActual)[fooMatcher](fooValue);
-          expect(barActual.serialize ? barActual.serialize() : barActual)[barMatcher](barValue);
+        var fooActual = display_prefs[func]("unit_test", "foo");
+        var barActual = display_prefs[func]("unit_test", "bar");
+       
+        expect(fooActual.serialize ? fooActual.serialize() : fooActual)[fooMatcher](fooValue);
+        expect(barActual.serialize ? barActual.serialize() : barActual)[barMatcher](barValue);
       }
 
       var exp_token;
@@ -131,7 +127,7 @@ describe("display prefs model", function() {
       });
 
       // TODO: figure out why these fail, error is "can.Map: Object does not exist thrown"
-      xdescribe("when set for a page", function() {
+      describe("when set for a page", function() {
         beforeEach(function() {
           display_prefs.makeObject(exp.path, exp_token).attr("foo", fooValue);
           display_prefs.makeObject(exp.path, exp_token).attr("bar", barValue);
@@ -143,7 +139,7 @@ describe("display prefs model", function() {
         it("returns the value set for the page", getTest);
       });
 
-      xdescribe("when not set for a page", function() {
+      describe("when not set for a page", function() {
         beforeEach(function() {
           display_prefs.makeObject(exp_token, "unit_test").attr("foo", fooValue);
           display_prefs.makeObject(exp_token, "unit_test").attr("bar", barValue);
@@ -157,11 +153,11 @@ describe("display prefs model", function() {
 
         it("sets the default value as the page value", function() {
           display_prefs[func]("unit_test", "foo");
-          var fooActual = display_prefs.attr([exp.path, exp_token, "foo"].join("."))
+          var fooActual = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
           expect(fooActual.serialize ? fooActual.serialize() : fooActual)[fooMatcher](fooValue);
         });
       });
-    }
+    };
   }
 
   describe("#getCollapsed", getSpecs("getCollapsed", "COLLAPSE", true, false));
@@ -181,21 +177,20 @@ describe("display prefs model", function() {
       });
 
       
-      // TODO: figure out why these fail, error is "can.Map: Object does not exist thrown"
-      // it("sets the value for a widget", function() {
-      //   display_prefs[func]("this arg is ignored", "foo", fooValue);
-      //   var fooActual  = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
-      //   expect(fooActual.serialize ? fooActual.serialize() : fooActual).toEqual(fooValue);
-      // });
+      it("sets the value for a widget", function() {
+        display_prefs[func]("this arg is ignored", "foo", fooValue);
+        var fooActual  = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
+        expect(fooActual.serialize ? fooActual.serialize() : fooActual).toEqual(fooValue);
+      });
 
-      // it("sets all values as a collection", function() {
-      //   display_prefs[func]("this arg is ignored", {"foo" : fooValue, "bar" : barValue});
-      //   var fooActual = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
-      //   var barActual = display_prefs.attr([exp.path, exp_token, "bar"].join("."));
-      //   expect(fooActual.serialize ? fooActual.serialize() : fooActual).toEqual(fooValue);
-      //   expect(barActual.serialize ? barActual.serialize() : barActual).toEqual(barValue);
-      // });
-    }
+      it("sets all values as a collection", function() {
+        display_prefs[func]("this arg is ignored", {"foo" : fooValue, "bar" : barValue});
+        var fooActual = display_prefs.attr([exp.path, exp_token, "foo"].join("."));
+        var barActual = display_prefs.attr([exp.path, exp_token, "bar"].join("."));
+        expect(fooActual.serialize ? fooActual.serialize() : fooActual).toEqual(fooValue);
+        expect(barActual.serialize ? barActual.serialize() : barActual).toEqual(barValue);
+      });
+    };
   }
 
   describe("#setSorts", setSpecs("setSorts", "SORTS", ["bar", "baz"], ["thud", "jeek"]));
@@ -222,7 +217,7 @@ describe("display prefs model", function() {
 
   describe("#setColumnWidths", setSpecs("setColumnWidths", "COLUMNS", [6,6], [4,8]));
 
-  xdescribe("Set/Reset functions", function() {
+  describe("Set/Reset functions", function() {
 
     describe("#resetPagePrefs", function() {
 
@@ -243,7 +238,7 @@ describe("display prefs model", function() {
         display_prefs.resetPagePrefs();
         can.each(["getSorts", "getCollapsed", "getWidgetHeight", "getColumnWidths"], function(func) {
           expect(display_prefs[func]("unit_test", "foo")).toBe("bar");
-        })
+        });
       });
 
     });
@@ -358,34 +353,6 @@ describe("display prefs model", function() {
         fail("Should have resolved on findOne for the current display pref");
       });
     });
-  });
-
-  describe("PBC-only functions", function() {
-
-    describe("#getPbcListPrefs", function() {
-
-    });
-
-    describe("#setPbcListPrefs", function() {
-
-    });
-
-    describe("#getPbcResponseOpen", function() {
-
-    });
-
-    describe("#getPbcRequestOpen", function() {
-
-    });
-
-    describe("#setPbcResponseOpen", function() {
-
-    });
-
-    describe("#setPbcRequestOpen", function() {
-
-    });
-
   });
 
 });

--- a/src/ggrc/assets/js_specs/models/local_storage_spec.js
+++ b/src/ggrc/assets/js_specs/models/local_storage_spec.js
@@ -11,8 +11,8 @@
 describe("can.Model.LocalStorage", function() {
   
   //run-once setup
-  beforeAll(function() {    
-      can.Model.LocalStorage("SpecModel");
+  beforeAll(function() {
+    can.Model.LocalStorage("SpecModel");
   });
 
   var model1 = { "id" : 1, "foo" : "bar" };

--- a/src/ggrc/assets/js_specs/models/mappers_spec.js
+++ b/src/ggrc/assets/js_specs/models/mappers_spec.js
@@ -5,7 +5,6 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
-
 describe("mappers", function() {
   
   var LL;

--- a/src/ggrc/assets/js_specs/spec_helpers.js
+++ b/src/ggrc/assets/js_specs/spec_helpers.js
@@ -6,11 +6,21 @@
 
 // polls check function and calls done when truthy
 function waitsFor(check, done) {
-    if (!check()) {
-        setTimeout(function () {
-            waitsFor(check, done);
-        }, 1);
-    }else{
-        done();
-    }
+  if (!check()) {
+    setTimeout(function () {
+      waitsFor(check, done);
+    }, 1);
+  } else {
+    done();
+  }
+}
+
+// This is primarily useful for passing as the fail case for
+//  promises, since every item passed to it will show up in 
+//  the jasmine output.
+window.failAll = function(done) {
+  return function() {
+    can.each(arguments, fail);
+    done && done();
+  };
 };


### PR DESCRIPTION
more to go but this is a good start

Also, can.Model.Cacheable.refresh() (as distinct from can.Model.Cacheable.prototype.refresh) was removed since it didn't work at all.