### PR TITLE
Handle case when workflow has no tasks.

### DIFF
--- a/src/ggrc_workflows/services/workflow_date_calculator.py
+++ b/src/ggrc_workflows/services/workflow_date_calculator.py
@@ -111,7 +111,7 @@ class WorkflowDateCalculator(object):
     min_relative_start_month = self._min_relative_start_month_from_tasks()
 
     # Both min_relative_start values will be None when the workflow has no tasks.
-    if min_relative_start_day is None or min_relative_start_month is None:
+    if min_relative_start_day is None and min_relative_start_month is None:
       return None
 
     return WorkflowDateCalculator.nearest_start_date_after_basedate_from_dates(

--- a/src/ggrc_workflows/services/workflow_date_calculator.py
+++ b/src/ggrc_workflows/services/workflow_date_calculator.py
@@ -89,6 +89,9 @@ class WorkflowDateCalculator(object):
   '''
   @staticmethod
   def nearest_work_day(date_, direction):
+    if date_ is None:
+      return None
+
     holidays = []
     while date_.isoweekday() > 5 or date_ in holidays:
       date_ = date_ + timedelta(direction)
@@ -106,12 +109,20 @@ class WorkflowDateCalculator(object):
     frequency = self.workflow.frequency
     min_relative_start_day = self._min_relative_start_day_from_tasks()
     min_relative_start_month = self._min_relative_start_month_from_tasks()
+
+    # Both min_relative_start values will be None when the workflow has no tasks.
+    if min_relative_start_day is None or min_relative_start_month is None:
+      return None
+
     return WorkflowDateCalculator.nearest_start_date_after_basedate_from_dates(
       basedate, frequency, min_relative_start_month, min_relative_start_day)
 
   @staticmethod
   def nearest_start_date_after_basedate_from_dates(
       basedate, frequency, relative_start_month, relative_start_day):
+
+    if basedate is None:
+      return None
 
     basedate_day_of_week = basedate.isoweekday()
     basedate_day_of_month = basedate.day
@@ -206,6 +217,9 @@ class WorkflowDateCalculator(object):
 
   @staticmethod
   def nearest_end_date_after_start_date_from_dates(frequency, start_date, end_month, end_day):
+    # Handle no start_date, which will happen when the workflow has no tasks.
+    if start_date is None:
+      return None
 
     start_date_day_of_week = start_date.isoweekday()
     start_date_day_of_month = start_date.day
@@ -302,6 +316,9 @@ class WorkflowDateCalculator(object):
 
   @staticmethod
   def next_cycle_start_date_after_start_date(start_date, frequency):
+    if start_date is None:
+      return None
+
     if "one_time" == frequency:
       return start_date
     elif "weekly" == frequency:
@@ -330,7 +347,8 @@ class WorkflowDateCalculator(object):
       next_cycle_start_date_after_start_date(start_date, frequency)
 
   @staticmethod
-  def previous_cycle_start_date_before_basedate_from_dates(basedate, frequency, relative_start_month, relative_start_day):
+  def previous_cycle_start_date_before_basedate_from_dates(
+      basedate, frequency, relative_start_month, relative_start_day):
     start_date = WorkflowDateCalculator.\
       nearest_start_date_after_basedate_from_dates(
       basedate, frequency, relative_start_month, relative_start_day)
@@ -339,6 +357,9 @@ class WorkflowDateCalculator(object):
 
   @staticmethod
   def previous_cycle_start_date(start_date, frequency):
+    if start_date is None:
+      return None
+
     if "one_time" == frequency:
       return start_date
     elif "weekly" == frequency:

--- a/src/tests/ggrc/test_workflow_date_calculator.py
+++ b/src/tests/ggrc/test_workflow_date_calculator.py
@@ -700,6 +700,26 @@ class TestWorkflowDateCalculator(TestCase):
     self.assertEqual(self.friday(), WorkflowDateCalculator.adjust_end_date(self.saturday()))
     self.assertEqual(self.friday(), WorkflowDateCalculator.adjust_end_date(self.sunday()))
 
+  def test_update_state_on_workflows_without_tasks(self):
+    workflows = [
+        self._create_one_time_workflow(),
+        self._create_weekly_workflow(),
+        self._create_monthly_workflow(),
+        self._create_quarterly_workflow(),
+        self._create_annual_workflow(),
+    ]
+    for workflow in workflows:
+      calculator = WorkflowDateCalculator(workflow)
+      next_cycle_start_date = \
+          WorkflowDateCalculator.adjust_start_date(calculator.nearest_start_date_after_basedate(self.today()))
+      next_cycle_end_date = \
+          WorkflowDateCalculator.adjust_end_date(calculator.nearest_end_date_after_start_date(next_cycle_start_date))
+      # Check the previous cycle to see if today is mid_cycle.
+      previous_cycle_start_date = \
+          WorkflowDateCalculator.adjust_start_date(calculator.previous_cycle_start_date_before_basedate(self.today()))
+      previous_cycle_end_date = \
+          WorkflowDateCalculator.adjust_end_date(calculator.nearest_end_date_after_start_date(previous_cycle_start_date))
+
 if __name__ == '__main__':
   import unittest
   unittest.main()


### PR DESCRIPTION
An alternate approach to #2268 as a solution for CORE-1098.

In summary, when the workflow has no tasks None will be returned for start date.
All other methods that take starting or relative dates will return None when the basedate/start_date, etc. is None (which will be the case when calculating for a workflow with no tasks).