### PR TITLE
CORE-1159 Re-adding missing icons for widget headers

### DIFF
--- a/src/ggrc/assets/mustache/dashboard/object_widget.mustache
+++ b/src/ggrc/assets/mustache/dashboard/object_widget.mustache
@@ -417,6 +417,7 @@
   {{^is_dashboard}}
     <header class="header">
       <h2>
+        <i class="grcicon-workflow-color"></i>
         {{{widget_name}}}
       </h2>
     </header>
@@ -427,6 +428,7 @@
   {{^is_dashboard}}
     <header class="header">
       <h2>
+        <i class="grcicon-event-color"></i>
         {{{widget_name}}}
       </h2>
     </header>
@@ -437,6 +439,7 @@
   {{^is_dashboard}}
     <header class="header">
       <h2>
+        <i class="{{widget_icon}}"></i>
         {{{widget_name}}}
       </h2>
     </header>


### PR DESCRIPTION
Hey @vladan-mitevski some of these icons were removed in https://github.com/reciprocity/ggrc-core/pull/2248 was there a reason for removing them?