### PR TITLE
CORE-1195 Reduce the number of requests sent on my dahsboard

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/quick_form_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/quick_form_controller.js
@@ -18,7 +18,9 @@ GGRC.Controllers.Modals("GGRC.Controllers.QuickForm", {
       this.options.model = this.options.instance.constructor;
     }
     this.options.$content = this.element;
-    this.options.instance.refresh();
+    if (this.element.data('force-refresh')) {
+      this.options.instance.refresh();
+    }
   }
 
   , "input, textarea, select change" : function(el, ev) {
@@ -241,14 +243,14 @@ can.Component.extend({
         multi_map = data.multi_map,
         join_model_class,
         join_object;
-      
+
       if(multi_map){
-        var length = data.arr.length, 
+        var length = data.arr.length,
             my_data;
 
         if (length == 1){
           my_data = data.arr[0];
-          
+
           GGRC.Mappings.make_join_object(
             this.scope.parent_instance,
             my_data,
@@ -261,11 +263,11 @@ can.Component.extend({
             that.element.find("a[data-toggle=submit]").trigger("modal:success");
           });
         }
-      
+
         else{
           for(var i = 0; i < length-1; i++){
             my_data = data.arr[i];
-            
+
             GGRC.Mappings.make_join_object(
               this.scope.parent_instance,
               my_data,

--- a/src/ggrc/assets/mustache/requests/info.mustache
+++ b/src/ggrc/assets/mustache/requests/info.mustache
@@ -53,7 +53,7 @@
             {{/using}}
           {{/if}}
         </div>
-        <div class="span6" {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
+        <div class="span6" data-force-refresh="true" {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
           <h6>Assignee</h6>
           {{#using assignee=instance.assignee}}
             {{{renderLive '/static/mustache/people/popover.mustache' person=assignee}}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -38,9 +38,15 @@
           {{#if_cycle_assignee_privileges instance}}
           <div data-force-refresh="true" {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
             {{#using contact=instance.contact}}
-              {{firstnonempty contact.name contact.email ''}}
+              <div class="objective-selector">
+                <input type="text" name="contact.name" data-lookup="Person" data-params="Person:is_enabled=1" class="search-icon input-block-level" {{#if_equals instance.status 'Verified'}}disabled="disabled"{{/if}} placeholder="Choose Assignee" value="{{firstnonempty contact.name contact.email ''}}">
+              </div>
             {{/using}}
           </div>
+          {{else}}
+            {{#using contact=instance.contact}}
+            <div>{{firstnonempty contact.name contact.email ''}}</div>
+            {{/using}}
           {{/if_cycle_assignee_privileges}}
         </div>
       </div>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -36,7 +36,7 @@
         <div class="span6">
           <h6>Assignee</h6>
           {{#if_cycle_assignee_privileges instance}}
-          <div {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
+          <div data-force-refresh="true" {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
             {{#using contact=instance.contact}}
               {{firstnonempty contact.name contact.email ''}}
             {{/using}}


### PR DESCRIPTION
quick_form was refreshing every instance by default which makes no sense inside tree views. This change makes quick_form force a refresh only inside info.mustache files.

With this PR I got the number of requests made by the new my dashboard with 250 tasks from 500+ to a bit over 100 - a significant improvement, but I think this can be further improved by investigating how the workflows are being loaded. There are still a bunch of /api/cycle requests not being batched together.