### PR TITLE
Cosmetic changes + fix CORE-1194

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -92,7 +92,7 @@ can.Control("CMS.Controllers.TreeLoader", {
       if (this.element.next().length > 0)
         return;
 
-      $footer = this.element.children('.tree-footer').first()
+      $footer = this.element.children('.tree-footer').first();
       spinner = new Spinner({
           "radius": 4
         , "length": 4
@@ -131,7 +131,7 @@ can.Control("CMS.Controllers.TreeLoader", {
 
     this._attached_deferred.then(function() {
       if (that.element) {
-        that.element.trigger("updateCount", 0)
+        that.element.trigger("updateCount", 0);
         that.init_count();
       }
     });
@@ -191,7 +191,7 @@ can.Control("CMS.Controllers.TreeLoader", {
       }
     });
 
-    temp_list = can.map(temp_list, function(o) { if (o.instance.selfLink) return o; })
+    temp_list = can.map(temp_list, function(o) { if (o.instance.selfLink) return o; });
     this._draw_list_deferred = this.enqueue_items(temp_list);
     return this._draw_list_deferred;
   }

--- a/src/ggrc/assets/stylesheets/_modal.scss
+++ b/src/ggrc/assets/stylesheets/_modal.scss
@@ -123,9 +123,9 @@
             font-size:$f-regular;
           }
           select.role {
-						margin:5px 5px 0 0;
-						width:120px;
-					}
+            margin:5px 5px 0 0;
+            width:120px;
+          }
           a {
             display:block;
             padding-left:10px;
@@ -411,7 +411,7 @@
     .modal-dismiss {
       margin-top: 1px;
       margin-right: -4px;
-      @include opacity(.3);
+      @include opacity(0.3);
       &:hover {
         @include opacity(1);
       }
@@ -537,7 +537,7 @@
     }
     label {
       font-weight: normal;
-      color:#111;
+      color: #111;
       font-size: 16px;
       margin-bottom: 7px;
       &.inline-check {
@@ -556,7 +556,7 @@
       }
       i {
         @include opacity(0.2);
-        cursor:pointer;
+        cursor: pointer;
         margin: 1px 4px 0 0;
         &:hover {
           @include opacity(0.7);

--- a/src/ggrc/assets/stylesheets/_modal.scss
+++ b/src/ggrc/assets/stylesheets/_modal.scss
@@ -557,7 +557,7 @@
       i {
         @include opacity(0.2);
         cursor: pointer;
-        margin: 1px 4px 0 0;
+        margin: 0 4px 0 0;
         &:hover {
           @include opacity(0.7);
         }

--- a/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
@@ -1,14 +1,33 @@
 <div class="row-fluid wrap-row">
   <div class="span12 small-info ">
-    <h6>{{instance.class.title_singular}} Folder <i class="grcicon-help-black" style="margin-top:0px;" rel="tooltip" data-original-title="If selected, all {{instance.class.title_singular}} attachments go here."></i></h6>
-      {{#if _folder_change_pending}}
-        <span {{attach_spinner '{ "radius": 2.5, "length": 2.5, "width": 2 }' 'display:inline-block; top: -5px; left: 8px;' }}></span>
-      {{else}}
-        {{#if current_folder}}
-          <div class="oneline">
-            <a href="{{current_folder.alternateLink}}" target="_blank">
-              <i class="grcicon-attach-color"></i> {{current_folder.title}}
-            </a>
+    <h6>
+      {{instance.class.title_singular}} Folder <i class="grcicon-help-black" style="margin-top:0px;" rel="tooltip" data-original-title="If selected, all {{instance.class.title_singular}} attachments go here."></i>
+    </h6>
+    {{#if _folder_change_pending}}
+      <span {{attach_spinner '{ "radius": 2.5, "length": 2.5, "width": 2 }' 'display:inline-block; top: -5px; left: 8px;' }}></span>
+    {{else}}
+      {{#if current_folder}}
+        <div class="oneline">
+          <a href="{{current_folder.alternateLink}}" target="_blank">
+            <i class="grcicon-attach-color"></i> {{current_folder.title}}
+          </a>
+          {{^if readonly}}
+          <a class="icon-link entry-attachment" href="javascript://" rel="tooltip" data-original-title="{{firstnonempty placeholder 'Choose a new folder'}}" data-toggle="gdrive-picker" data-model="{{instance.class.model_singular}}" data-id="{{instance.id}}" data-type="folders" data-replace="true">
+            <i class="grcicon-edit"></i>
+          </a>
+          {{^if no_detach}}
+          <a class="icon-link" href="javascript://" rel="tooltip" data-original-title="Detach folder from {{instance.class.title_singular}}" data-toggle="gdrive-remover"
+            data-model="{{instance.class.model_singular}}" data-id="{{instance.id}}">
+            <i class="grcicon-deleted"></i>
+          </a>
+          {{/if}}
+          {{/if}}
+        </div>
+        {{else}}
+          {{#if folder_error}}
+            <small>
+              <strong>Warning:</strong> You need permission to access {{instance.class.title_singular}} folder. <a href="https://drive.google.com/folderview?id={{grdive_msg_to_id folder_error.message}}&usp=sharing#">Request access.</a>
+            </small>
             {{^if readonly}}
             <a class="icon-link entry-attachment" href="javascript://" rel="tooltip" data-original-title="{{firstnonempty placeholder 'Choose a new folder'}}" data-toggle="gdrive-picker" data-model="{{instance.class.model_singular}}" data-id="{{instance.id}}" data-type="folders" data-replace="true">
               <i class="grcicon-edit"></i>
@@ -20,35 +39,18 @@
             </a>
             {{/if}}
             {{/if}}
-          </div>
           {{else}}
-            {{#if folder_error}}
-              <small>
-                <strong>Warning:</strong> You need permission to access {{instance.class.title_singular}} folder. <a href="https://drive.google.com/folderview?id={{grdive_msg_to_id folder_error.message}}&usp=sharing#">Request access.</a>
-              </small>
-              {{^if readonly}}
-              <a class="icon-link entry-attachment" href="javascript://" rel="tooltip" data-original-title="{{firstnonempty placeholder 'Choose a new folder'}}" data-toggle="gdrive-picker" data-model="{{instance.class.model_singular}}" data-id="{{instance.id}}" data-type="folders" data-replace="true">
-                <i class="grcicon-edit"></i>
-              </a>
-              {{^if no_detach}}
-              <a class="icon-link" href="javascript://" rel="tooltip" data-original-title="Detach folder from {{instance.class.title_singular}}" data-toggle="gdrive-remover"
-                data-model="{{instance.class.model_singular}}" data-id="{{instance.id}}">
-                <i class="grcicon-deleted"></i>
-              </a>
-              {{/if}}
-              {{/if}}
-            {{else}}
-              <span class="error">
-                No folder for this {{instance.class.title_singular}}.
-              </span>
-              {{^if readonly}}
-              <a href="javascript://" tabindex="{{firsnonempty tabindex '0'}}" class="entry-attachment tree-item-add" data-toggle="gdrive-picker"
-                data-model="{{instance.class.model_singular}}" data-type="folders" data-id="{{instance.id}}">
-                <i class="grcicon-attach-color"></i> Assign folder
-              </a>
-              {{/if}}
+            <span class="error">
+              No folder for this {{instance.class.title_singular}}.
+            </span>
+            {{^if readonly}}
+            <a href="javascript://" tabindex="{{firsnonempty tabindex '0'}}" class="entry-attachment tree-item-add" data-toggle="gdrive-picker"
+              data-model="{{instance.class.model_singular}}" data-type="folders" data-id="{{instance.id}}">
+              <i class="grcicon-attach-color"></i> Assign folder
+            </a>
             {{/if}}
-        {{/if}}
+          {{/if}}
       {{/if}}
+    {{/if}}
   </div>
 </div>

--- a/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
@@ -1,7 +1,7 @@
 <div class="row-fluid wrap-row">
   <div class="span12 small-info ">
     <h6>
-      {{instance.class.title_singular}} Folder <i class="grcicon-help-black" style="margin-top:0px;" rel="tooltip" data-original-title="If selected, all {{instance.class.title_singular}} attachments go here."></i>
+      {{instance.class.title_singular}} Folder <label style="display: inline"><i class="grcicon-help-black" rel="tooltip" data-original-title="If selected, all {{instance.class.title_singular}} attachments go here."></i></label>
     </h6>
     {{#if _folder_change_pending}}
       <span {{attach_spinner '{ "radius": 2.5, "length": 2.5, "width": 2 }' 'display:inline-block; top: -5px; left: 8px;' }}></span>

--- a/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
@@ -5,8 +5,7 @@
     Maintained By: dan@reciprocitylabs.com
 }}
 
-{{!div class="modal-body"}}
-<div class="hideable-holder"> 
+<div class="hideable-holder">
 <form action="javascript://">
   {{> /static/mustache/base_objects/form_restore.mustache}}
 
@@ -113,4 +112,3 @@
 
 </form>
 </div> 
-{{!/div}}


### PR DESCRIPTION
Debugging CORE-1194 reveals the cause to be the markup of the `ggrc-gdrive-folder-picker`: a `<label>` is needed  instead of the `h6`. Making the change looks great in the modal, but the same `ggrc-gdrive-folder-picker` is used in info tabs and tree info panes, whose field labels are h6's - [CORE-1220](https://reciprocitylabs.atlassian.net/browse/CORE-1220).

Hence the surgical fix of putting the `label` just around the icon, instead of it replacing the `h6`.