### PR TITLE
CORE 1213 and some other audit fixes

### DIFF
--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -253,6 +253,7 @@ $(function() {
   //  objects.
   var info_widget_views = {
       'programs': GGRC.mustache_path + "/programs/info.mustache"
+    , 'audits': GGRC.mustache_path + "/audits/info.mustache"
     , 'people': GGRC.mustache_path + "/people/info.mustache"
     , 'policies': GGRC.mustache_path + "/policies/info.mustache"
     , 'sections': GGRC.mustache_path + "/sections/info.mustache"

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -230,7 +230,7 @@ can.Control("GGRC.Controllers.Modals", {
       // Make sure custom attributes are preloaded:
       dfd = dfd.then(function(){
         return $.when(
-          instance.load_custom_attribute_definitions(),
+          instance.load_custom_attribute_definitions && instance.load_custom_attribute_definitions(),
           instance.custom_attribute_values ? instance.refresh_all('custom_attribute_values') : []
         );
       });
@@ -240,7 +240,7 @@ can.Control("GGRC.Controllers.Modals", {
       // If the modal is closed early, the element no longer exists
       if (that.element) {
         // Make sure custom attr validations/values are set
-        if (instance) {
+        if (instance && instance.setup_custom_attributes) {
           instance.setup_custom_attributes();
         }
         // This is to trigger `focus_first_element` in modal_ajax handling

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -101,13 +101,7 @@ can.Model.Cacheable("CMS.Models.Audit", {
       this.attr('context', this.program.reify().context);
     }
 
-    return this._super.apply(this, arguments).then(function(instance) {
-      // Since Audits have a non-standard url for viewing, the url has to be set here
-      // so that the browser can be redirected properly after creating.
-      instance.attr('_redirect',
-        instance.program.reify().viewLink + "#audit_widget/audit/" + instance.id);
-      return instance;
-    });
+    return this._super.apply(this, arguments);
   },
   after_save: function() {
     var that = this;

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -20,12 +20,14 @@
       <div class="details-wrap">
         <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
         <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+          {{#is_info_pin}}
           <li>
             <a href="{{viewLink}}">
               <i class="grcicon-goto"></i>
               View {{instance.class.title_singular}}
             </a>
           </li>
+          {{/is_info_pin}}
           {{#if_helpers '\
             #is_page_instance' instance.program '\
             or #is_profile'}}
@@ -48,8 +50,8 @@
   	        {{/is_allowed}}
           {{/if_helpers}}
           {{#is_allowed 'update' instance context='for'}}
-            <li class="border">
-              <a href="javascript://" data-toggle="modal-ajax-form" data-modal-reset="reset" data-modal-class="modal-wide" data-object-singular="Audit" data-object-plural="audits" data-object-id="{{instance.id}}" data-object-params='{ "{{options.parent_instance.class.table_singular}}": { "id" : {{options.parent_instance.id}}, "title" : "{{options.parent_instance.title}}" } }'>
+            <li>
+              <a href="javascript://" data-toggle="modal-ajax-form" data-modal-reset="reset" data-modal-class="modal-wide" data-object-singular="Audit" data-object-plural="audits" data-object-id="{{instance.id}}" data-object-params='{{#options}}{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" } }{{/options}}'>
                 <i class="grcicon-edit"></i>
                 Edit {{model.title_singular}}
               </a>

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -10,11 +10,11 @@
     {{#is_info_pin}}
     <div class="clearfix">
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
-      <div class="tier-content">
-        {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
-      </div>
     </div>
     {{/is_info_pin}}
+    <div class="tier-content">
+      {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
+    </div>
 
     {{#is_allowed 'update' instance context='for'}}
       <div class="details-wrap">


### PR DESCRIPTION
This fixes the script error in gdrive modals and adds audit/info.mustache to audit info page instead of base_objects/info.mustache.