### PR TITLE
Reverting changes by pull request 2353, CORE-1310

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -19,7 +16,7 @@
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
   </ul>
 </div>
-{{/if_helpers}}
+
 
 <div class="tier-content">
   {{{renderLive '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/controls/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/controls/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -19,7 +16,7 @@
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
   </ul>
 </div>
-{{/if_helpers}}
+
 
 <div class="tier-content">
   {{{renderLive '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/directives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/directives/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -19,7 +16,7 @@
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
   </ul>
 </div>
-{{/if_helpers}}
+
 
 <div class="tier-content">
   {{{renderLive '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/documents/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/documents/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or ^is_dashboard" "\
-   or #is_allowed" "update" instance}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -29,7 +26,7 @@
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
   </ul>
 </div>
-{{/if_helpers}}
+
 
 <div class="tier-content">
   {{#instance.description}}

--- a/src/ggrc/assets/mustache/objectives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -19,7 +16,7 @@
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
   </ul>
 </div>
-{{/if_helpers}}
+
 
 <div class="tier-content">
   {{{renderLive '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/people/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/people/tier2_content.mustache
@@ -1,6 +1,4 @@
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or" options.allowed_mapping}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -20,7 +18,7 @@
     {{/if}}
   </ul>
 </div>
-{{/if_helpers}}
+
 
 <div class="tier-content">
   {{#if instance.email}}

--- a/src/ggrc/assets/mustache/programs/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/programs/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   #is_allowed" "view_object_page" "Program" context=instance.context "\
-   or" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -19,7 +16,6 @@
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
   </ul>
 </div>
-{{/if_helpers}}
 
 <div class="tier-content">
   {{{renderLive '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/sections/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/sections/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   " instance.viewLink "\
-   or #is_allowed" "update" instance "\
-   or" allow_mapping_or_creating}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -72,7 +69,7 @@
     {{/if}}
   </ul>
 </div>
-{{/if_helpers}}
+
 
 <div class="tier-content">
   {{{renderLive '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
@@ -1,7 +1,4 @@
-{{#if_helpers "\
-   " instance.viewLink "\
-   or" options.allow_mapping "\
-   or #is_allowed" "update" instance context='for'}}
+
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
@@ -10,7 +7,6 @@
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
   </ul>
 </div>
-{{/if_helpers}}
 
 <div class="tier-content">
   {{{renderLive '/static/mustache/base_objects/general_info.mustache' instance=instance }}}


### PR DESCRIPTION
Advanced search and all map modals can't load the file with "\" in the tier-2 content file.
Instead of {{#if_helpers "\
   #is_allowed" "view_object_page" instance "\
   or" options.allow_mapping "\
   or #is_allowed" "update" instance}}

it is advised to write a mustache helper for the purpose. 