### PR TITLE
CORE-1199: don't show cog icon when not needed

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
@@ -1,6 +1,6 @@
 {{#if_helpers "\
    #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
+   or " options.allow_mapping "\
    or #is_allowed" "update" instance}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>

--- a/src/ggrc/assets/mustache/controls/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/controls/tier2_content.mustache
@@ -1,6 +1,6 @@
 {{#if_helpers "\
    #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
+   or " options.allow_mapping "\
    or #is_allowed" "update" instance}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>

--- a/src/ggrc/assets/mustache/directives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/directives/tier2_content.mustache
@@ -1,6 +1,6 @@
 {{#if_helpers "\
    #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
+   or " options.allow_mapping "\
    or #is_allowed" "update" instance}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>

--- a/src/ggrc/assets/mustache/objectives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/tier2_content.mustache
@@ -1,6 +1,6 @@
 {{#if_helpers "\
    #is_allowed" "view_object_page" instance "\
-   or" options.allow_mapping "\
+   or " options.allow_mapping "\
    or #is_allowed" "update" instance}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>

--- a/src/ggrc/assets/mustache/people/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/people/tier2_content.mustache
@@ -1,6 +1,6 @@
 {{#if_helpers "\
    #is_allowed" "view_object_page" instance "\
-   or" options.allowed_mapping}}
+   or " options.allowed_mapping}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">

--- a/src/ggrc/assets/mustache/programs/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/programs/tier2_content.mustache
@@ -1,7 +1,7 @@
 {{#if_helpers "\
-   #is_allowed" "view_object_page" "Program" context=instance.context "\
-   or" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
+   " options.allow_mapping "\
+   or #is_allowed" "update" instance "\
+   or #is_allowed" "view_object_page" "Program" context=instance.context}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">

--- a/src/ggrc/assets/mustache/sections/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/sections/tier2_content.mustache
@@ -1,7 +1,7 @@
 {{#if_helpers "\
    " instance.viewLink "\
    or #is_allowed" "update" instance "\
-   or" allow_mapping_or_creating}}
+   or " allow_mapping_or_creating}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">

--- a/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
@@ -1,6 +1,6 @@
 {{#if_helpers "\
    " instance.viewLink "\
-   or" options.allow_mapping "\
+   or " options.allow_mapping "\
    or #is_allowed" "update" instance context='for'}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>


### PR DESCRIPTION
Ok so this is now a mess. We need somebody with high git-fu to fix it. @zidarsk8 or @Smotko maybe?

1) All these changes are needed: https://github.com/reciprocity/ggrc-core/pull/2353

2) But this PR killed them: https://github.com/reciprocity/ggrc-core/pull/2356

So now there is a merge conflict.

PS: @sasmita514 making a new mustache helper for this use-case doesn't solve anything because we've already got `if_helpers` and its replacement wouldn't be any easier to use.

PPS: if I do a rebase locally, all changes from the original PR vanish because, well, that's what the tree says. Git just fast-forwards because hey, it looks fast forwardable.