### PR TITLE
Dashboard task-progress bar fix, CORE-1315

### DIFF
--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -373,7 +373,7 @@ small {
     height: 20px;
     @include box-shadow(none);
     float: left;
-    margin-right: 1px;
+    margin-right: 0px;
   }
 
   @each $bar_color in verify, progress, pending, warning {


### PR DESCRIPTION
- When total % becomes 100%, there is no space for right margin. So removed the right margin.
