### PR TITLE
filter hiding code belongs in TreeView now

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
@@ -28,34 +28,29 @@ CMS.Controllers.Filterable("CMS.Controllers.DashboardWidgets", {
 }, {
 
   init : function() {
-    CMS.Models.DisplayPrefs.getSingleton().then(function (prefs) {
-      this.display_prefs = prefs;
+    if(!this.options.model && GGRC.page_model) {
+      this.options.model = GGRC.infer_object_type(GGRC.page_object);
+    }
 
-      if(!this.options.model && GGRC.page_model) {
-        this.options.model = GGRC.infer_object_type(GGRC.page_object);
-      }
+    if(!this.options.widget_icon && this.options.model) {
+      this.options.widget_icon = this.options.model.table_singular;
+    }
+    if(this.options.widget_icon && !/^grcicon/.test(this.options.widget_icon)) {
+      this.options.widget_icon = "grcicon-" + this.options.widget_icon + "-color";
+    }
 
-      if(!this.options.widget_icon && this.options.model) {
-        this.options.widget_icon = this.options.model.table_singular;
-      }
-      if(this.options.widget_icon && !/^grcicon/.test(this.options.widget_icon)) {
-        this.options.widget_icon = "grcicon-" + this.options.widget_icon + "-color";
-      }
+    if(!this.options.object_category && this.options.model) {
+      this.options.object_category = this.options.model.category;
+    }
 
-      if(!this.options.object_category && this.options.model) {
-        this.options.object_category = this.options.model.category;
-      }
-
-      this.options.widget_count = new can.Observe();
-      this.options.filter_is_hidden = this.display_prefs.getFilterHidden();
-
-      this.element
-            .addClass("widget")
-            .addClass(this.options.object_category)
-            .attr("id", this.options.widget_id + "_widget")
-        //  This is used only by ResizeWidgets controller
-            .trigger("section_created");
-    }.bind(this));
+    this.options.widget_count = new can.Observe();
+    
+    this.element
+          .addClass("widget")
+          .addClass(this.options.object_category)
+          .attr("id", this.options.widget_id + "_widget")
+      //  This is used only by ResizeWidgets controller
+          .trigger("section_created");
   }
 
   , prepare: function() {
@@ -166,41 +161,5 @@ CMS.Controllers.Filterable("CMS.Controllers.DashboardWidgets", {
         if (that.content_controller && that.content_controller.display_path)
           return that.content_controller.display_path(path);
       });
-    }
-
-  , ".filter-trigger > a click": function (element, event) {
-      if (element.hasClass("active")) {
-        this.hide_filter();
-      }else{
-        this.show_filter();
-      }
-    }
-
-  , hide_filter: function () {
-      var $filter = this.element.find(".filter-holder");
-
-      $filter
-          .data("height", $filter.height())
-          .animate({height: 0},
-                   {duration: 800,
-                    easing: 'easeOutExpo'});
-      this.element.find(".filter-trigger > a").removeClass("active");
-
-      this.display_prefs.setFilterHidden(true);
-      this.display_prefs.save();
-    }
-
-  , show_filter: function () {
-      var $filter = this.element.find(".filter-holder");
-
-      $filter
-          .animate({height: $filter.data("height")},
-                   {duration: 800,
-                    easing: 'easeOutExpo'});
-
-      this.element.find(".filter-trigger > a").addClass("active");
-
-      this.display_prefs.setFilterHidden(false);
-      this.display_prefs.save();
     }
 });

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -359,6 +359,9 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
 
   , init : function(el, opts) {
     CMS.Models.DisplayPrefs.getSingleton().then(function (display_prefs) {
+      this.display_prefs = display_prefs;
+      this.options.filter_is_hidden = this.display_prefs.getFilterHidden();
+
       this.element.uniqueId();
 
       if('parent_instance' in opts && 'status' in opts.parent_instance){
@@ -797,6 +800,43 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
       this.options.events[event_name].apply(this, arguments);
     }
   },
+
+
+  ".filter-trigger > a click": function (element, event) {
+      if (element.hasClass("active")) {
+        this.hide_filter();
+      }else{
+        this.show_filter();
+      }
+    }
+
+  , hide_filter: function () {
+      var $filter = this.element.find(".filter-holder");
+
+      $filter
+          .data("height", $filter.height())
+          .animate({height: 0},
+                   {duration: 800,
+                    easing: 'easeOutExpo'});
+      this.element.find(".filter-trigger > a").removeClass("active");
+
+      this.display_prefs.setFilterHidden(true);
+      this.display_prefs.save();
+    }
+
+  , show_filter: function () {
+      var $filter = this.element.find(".filter-holder");
+
+      $filter
+          .animate({height: $filter.data("height")},
+                   {duration: 800,
+                    easing: 'easeOutExpo'});
+
+      this.element.find(".filter-trigger > a").addClass("active");
+
+      this.display_prefs.setFilterHidden(false);
+      this.display_prefs.save();
+    }
 });
 
 can.Control("CMS.Controllers.TreeViewNode", {


### PR DESCRIPTION
After the refactor, it no longer makes sense for filter hiding code to stay in the dashboard widgets controller.