### PR TITLE
CORE-962: move import/export links to header

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
@@ -1499,7 +1499,7 @@
         // Calculate the total number of options
         var option_type_count = 0;
         if (this.options.option_type_menu) {
-          can.each(this.options.option_type_menu, function(type) { option_type_count += type.items.length; })
+          can.each(this.options.option_type_menu, function(type) { option_type_count += type.items.length; });
         }
 
         var display_selection = this.options.option_descriptors[this.options.default_option_descriptor].model.title_plural;

--- a/src/ggrc/assets/mustache/base_objects/tree_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_header.mustache
@@ -41,11 +41,22 @@
           {{/is_allowed}}
         {{/if}}
         {{#if list.length}}
-          <li>
-            <a href="{{parent_instance.viewLink}}/export_{{model.table_plural}}?ids={{instance_ids list}}" class="section-import" rel="tooltip" data-placement="left" title="" data-original-title="Export {{model.model_plural}}">
-              <i class="grcicon-export"></i>
-            </a>
-          </li>
+            {{log model.root_object}}
+            {{#if_helpers '\
+               #if_equals' model.shortName 'Control' '\
+               and #if_instance_of' parent_instance 'Directive|Program' '\
+               or #if_equals' model.shortName 'Objective' '\
+               and #if_instance_of' parent_instance 'Directive|Program|Regulation|Policy|Standard|Contract' '\
+               or #if_equals' model.shortName 'Section' '\
+               and #if_instance_of' parent_instance 'Directive' '\
+               or #if_equals' model.shortName 'System' '\
+               and #if_instance_of' parent_instance 'Program'}}
+                <li>
+                  <a href="{{parent_instance.viewLink}}/export_{{model.table_plural}}?ids={{instance_ids list}}" class="section-import" rel="tooltip" data-placement="left" title="" data-original-title="Export {{model.model_plural}}">
+                    <i class="grcicon-export"></i>
+                  </a>
+                </li>
+            {{/if_instance_of}}
         {{/if}}
 
         <li class="filter-trigger">

--- a/src/ggrc/assets/mustache/base_objects/tree_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_header.mustache
@@ -31,6 +31,23 @@
     </div>
     <div class="span4">
       <ul class="tree-action-list">
+        {{#if allow_creating}}
+          {{#is_allowed 'create' model.shortName context=null}}
+            <li>
+              <a href="{{parent_instance.viewLink}}/import_{{model.table_plural}}?return_to={{param_current_location}}" class="section-import" rel="tooltip" data-placement="left" title="" data-original-title="Import {{model.model_plural}}">
+                <i class="grcicon-imp-exp"></i>
+              </a>
+            </li>
+          {{/is_allowed}}
+        {{/if}}
+        {{#if list.length}}
+          <li>
+            <a href="{{parent_instance.viewLink}}/export_{{model.table_plural}}?ids={{instance_ids list}}" class="section-import" rel="tooltip" data-placement="left" title="" data-original-title="Export {{model.model_plural}}">
+              <i class="grcicon-export"></i>
+            </a>
+          </li>
+        {{/if}}
+
         <li class="filter-trigger">
           <a href="javascript://" {{^filter_is_hidden}}class="active"{{/filter_is_hidden}}>
             <i class="grcicon-search" rel="tooltip" data-placement="left" title="" data-original-title="Hide Filter"></i>

--- a/src/ggrc/assets/mustache/controls/tree_footer.mustache
+++ b/src/ggrc/assets/mustache/controls/tree_footer.mustache
@@ -8,87 +8,28 @@
 
 <!-- {{{renderLive '/static/mustache/base_objects/tree_footer_zero.mustache'}}} -->
 
+
+{{#is_allowed_to_map parent_instance model.shortName}}
 {{#if allow_mapping_or_creating}}
-{{#if_instance_of parent_instance 'Directive|Program'}}
-{{#if_helpers '\
-  #if' allow_mapping '\
-  and #is_allowed_to_map' parent_instance model.shortName '\
-  or #if' allow_creating '\
-  and #is_allowed' 'create' model.shortName _3_context=null '\
-  or #if' list.length}}
-<li class="tree-item tree-item-add">
+<li class="tree-item tree-item-add tree-footer">
   <div class="row-fluid">
-    <div class="span12 section-expandable">
-      <a href="javascript://" class="section-add btn btn-small btn-draft" rel="tooltip" data-placement="right" data-original-title="+ {{model.title_singular}}">
-        <i class="grcicon-add-black"></i>
-      </a>
-      <span class="section-expander">
-        {{#if allow_mapping}}
-        {{#is_allowed_to_map parent_instance model.shortName}}
+    <div class="span12">
         <a
+          class="section-add btn btn-small btn-draft"
           href="javascript://"
           rel="tooltip"
-          data-placement="right"
+          data-placement="left"
           data-toggle="multitype-multiselect-modal-selector"
           data-join-mapping="{{mapping}}"
           data-join-option-type="{{model.shortName}}"
           data-join-object-id="{{parent_instance.id}}"
           data-join-object-type="{{parent_instance.class.shortName}}"
+          data-exclude-option-types="{{exclude_option_types}}"
           data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-          Map {{model.title_singular}}
+            <i class="grcicon-add-black"></i>
         </a>
-        &nbsp;
-        &nbsp;
-        {{#if allow_creating}}
-        {{#is_allowed 'create' model.shortName context=null}}
-        <a href="{{parent_instance.viewLink}}/import_controls?return_to={{param_current_location}}" class="section-import">
-          <i class="grcicon-imp-exp"></i>
-          Import Controls
-        </a>
-        &nbsp;
-        &nbsp;
-        {{/is_allowed}}
-        {{/if}}
-        {{/is_allowed_to_map}}
-        {{/if}}
-        {{#if list.length}}
-        <a href="{{parent_instance.viewLink}}/export_controls?ids={{instance_ids list}}" class="section-import">
-          <i class="grcicon-export"></i>
-          Export Controls
-        </a>
-        {{/if}}
-      </span>
     </div>
   </div>
 </li>
-{{/if_helpers}}
-
-{{else}}
-
-{{#if allow_mapping}}
-{{#is_allowed_to_map parent_instance model.shortName}}
-
-<li class="tree-item tree-item-add">
-  <div class="row-fluid">
-    <div class="span12">
-      <a
-        class="btn btn-small btn-draft"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="right"
-        data-toggle="multitype-multiselect-modal-selector"
-        data-join-mapping="{{mapping}}"
-        data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-        <i class="grcicon-add-black"></i>
-      </a>
-    </div>
-  </div>
-</li>
-
+{{/if}}
 {{/is_allowed_to_map}}
-{{/if}}
-{{/if_instance_of}}
-{{/if}}

--- a/src/ggrc/assets/mustache/objectives/tree_footer.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree_footer.mustache
@@ -8,85 +8,28 @@
 
 <!-- {{{renderLive '/static/mustache/base_objects/tree_footer_zero.mustache'}}} -->
 
+
+{{#is_allowed_to_map parent_instance model.shortName}}
 {{#if allow_mapping_or_creating}}
-{{#if_instance_of parent_instance 'Program|Directive|Regulation|Policy|Standard|Contract'}}
-{{#if_helpers '\
-  #if' allow_mapping '\
-  and #is_allowed_to_map' parent_instance model.shortName '\
-  or #if' allow_creating '\
-  and #is_allowed' 'create' model.shortName _3_context=null '\
-  or #if' list.length}}
-<li class="tree-item tree-item-add">
+<li class="tree-item tree-item-add tree-footer">
   <div class="row-fluid">
-    <div class="span12 section-expandable">
-      <a href="javascript://" class="section-add btn btn-small btn-draft" rel="tooltip" data-placement="right" data-original-title="+ Objective">
-        <i class="grcicon-add-black"></i>
-      </a>
-      <span class="section-expander">
-        {{#if allow_mapping}}
-        {{#is_allowed_to_map parent_instance model.shortName}}
+    <div class="span12">
         <a
+          class="section-add btn btn-small btn-draft"
           href="javascript://"
           rel="tooltip"
-          data-placement="right"
+          data-placement="left"
           data-toggle="multitype-multiselect-modal-selector"
           data-join-mapping="{{mapping}}"
           data-join-option-type="{{model.shortName}}"
           data-join-object-id="{{parent_instance.id}}"
           data-join-object-type="{{parent_instance.class.shortName}}"
+          data-exclude-option-types="{{exclude_option_types}}"
           data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-          Map Objective
+            <i class="grcicon-add-black"></i>
         </a>
-        &nbsp;
-        &nbsp;
-        {{#if allow_creating}}
-        {{#is_allowed 'create' model.shortName context=null}}
-        <a href="{{parent_instance.viewLink}}/import_objectives?return_to={{param_current_location}}" class="section-import">
-          <i class="grcicon-imp-exp"></i>
-          Import Objectives
-        </a>
-        &nbsp;
-        &nbsp;
-        {{/is_allowed}}
-        {{/if}}
-        {{/is_allowed_to_map}}
-        {{/if}}
-        {{#if list.length}}
-        <a href="{{parent_instance.viewLink}}/export_objectives?ids={{instance_ids list}}" class="section-import">
-          <i class="grcicon-export"></i>
-          Export Objectives
-        </a>
-        {{/if}}
-      </span>
     </div>
   </div>
 </li>
-{{/if_helpers}}
-
-{{else}}
-
-{{#if allow_mapping}}
-{{#is_allowed_to_map parent_instance model.shortName}}
-<li class="tree-item tree-item-add">
-  <div class="row-fluid">
-    <div class="span12">
-      <a
-        class="btn btn-small btn-draft"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="right"
-        data-toggle="multitype-multiselect-modal-selector"
-        data-join-mapping="{{mapping}}"
-        data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-        <i class="grcicon-add-black"></i>
-      </a>
-    </div>
-  </div>
-</li>
+{{/if}}
 {{/is_allowed_to_map}}
-{{/if}}
-{{/if_instance_of}}
-{{/if}}

--- a/src/ggrc/assets/mustache/sections/tree_footer.mustache
+++ b/src/ggrc/assets/mustache/sections/tree_footer.mustache
@@ -8,24 +8,22 @@
 <!-- {{{renderLive '/static/mustache/base_objects/tree_footer_zero.mustache'}}} -->
 
 {{#is_allowed_to_map parent_instance model.shortName}}
-{{#if allow_mapping_or_creating}}
+{{#if allow_mapping}}
 <li class="tree-item tree-item-add tree-footer">
   <div class="row-fluid">
     <div class="span12">
-        <a
-          class="section-add btn btn-small btn-draft"
-          href="javascript://"
-          rel="tooltip"
-          data-placement="left"
-          data-toggle="multitype-multiselect-modal-selector"
-          data-join-mapping="{{mapping}}"
-          data-join-option-type="{{model.shortName}}"
-          data-join-object-id="{{parent_instance.id}}"
-          data-join-object-type="{{parent_instance.class.shortName}}"
-          data-exclude-option-types="{{exclude_option_types}}"
-          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-            <i class="grcicon-add-black"></i>
-        </a>
+      <a href="javascript://"
+         class="section-create btn btn-small btn-draft"
+         data-toggle="modal-ajax-form"
+         data-modal-reset="reset"
+         data-dirty="#regulations, #combo"
+         data-route="regulations"
+         data-modal-class="modal-wide"
+         data-object-singular="Section"
+         data-object-plural="sections"
+         data-object-singular-override="{{#if_instance_of parent_instance 'Contract'}}Clause{{/if_instance_of}}" data-object-params='{ "directive": {{parent_instance.id}} }'>
+          <i class="grcicon-add-black"></i>
+      </a>
     </div>
   </div>
 </li>

--- a/src/ggrc/assets/mustache/sections/tree_footer.mustache
+++ b/src/ggrc/assets/mustache/sections/tree_footer.mustache
@@ -7,20 +7,13 @@
 
 <!-- {{{renderLive '/static/mustache/base_objects/tree_footer_zero.mustache'}}} -->
 
+{{#is_allowed_to_map parent_instance model.shortName}}
 {{#if allow_mapping_or_creating}}
-{{#if_instance_of parent_instance 'Directive'}}
-{{#if allow_creating}}
-{{#is_allowed 'create' model.shortName context=null}}
-{{#if_instance_of parent_instance 'Contract|Standard|Policy|Regulation'}}
-<li class="tree-item tree-item-add">
+<li class="tree-item tree-item-add tree-footer">
   <div class="row-fluid">
-    <div class="span12 section-expandable">
-      <a href="javascript://" class="section-add btn btn-small btn-draft" rel="tooltip" data-placement="right" data-original-title="+ {{#if_instance_of parent_instance 'Contract'}}Clause{{else}}Section{{/if_instance_of}}">
-        <i class="grcicon-add-black"></i>
-      </a>
-      <span class="section-expander">
-        {{#if_instance_of parent_instance 'Contract'}}
+    <div class="span12">
         <a
+          class="section-add btn btn-small btn-draft"
           href="javascript://"
           rel="tooltip"
           data-placement="left"
@@ -29,76 +22,12 @@
           data-join-option-type="{{model.shortName}}"
           data-join-object-id="{{parent_instance.id}}"
           data-join-object-type="{{parent_instance.class.shortName}}"
+          data-exclude-option-types="{{exclude_option_types}}"
           data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-          Map {{model.title_singular}}
+            <i class="grcicon-add-black"></i>
         </a>
-        {{else}}
-        <a href="javascript://" class="section-create" data-toggle="modal-ajax-form" data-modal-reset="reset" data-dirty="#regulations, #combo" data-route="regulations" data-modal-class="modal-wide" data-object-singular="Section" data-object-plural="sections" data-object-singular-override="{{#if_instance_of parent_instance 'Contract'}}Clause{{/if_instance_of}}" data-object-params='{ "directive": {{parent_instance.id}} }'>
-          <i class="grcicon-add-black"></i>
-          Create {{#if_instance_of parent_instance 'Contract'}}Clause{{else}}Section{{/if_instance_of}}
-        </a>
-        {{/if_instance_of}}
-        &nbsp;
-        &nbsp;
-        {{#if_instance_of parent_instance 'Contract'}}
-        <a href="{{parent_instance.viewLink}}/import_clauses?return_to={{param_current_location}}" class="section-import">
-          <i class="grcicon-imp-exp"></i>
-          Import Clauses
-        </a>
-        &nbsp;
-        &nbsp;
-        {{#if list.length}}
-        <a href="{{parent_instance.viewLink}}/export_clauses" class="section-import">
-          <i class="grcicon-export"></i>
-          Export Clauses
-        </a>
-        {{/if}}
-        {{else}}
-        <a href="{{parent_instance.viewLink}}/import_sections?return_to={{param_current_location}}" class="section-import">
-          <i class="grcicon-imp-exp"></i>
-          Import Sections
-        </a>
-        &nbsp;
-        &nbsp;
-        {{#if list.length}}
-        <a href="{{parent_instance.viewLink}}/export_sections" class="section-import">
-          <i class="grcicon-export"></i>
-          Export Sections
-        </a>
-        {{/if}}
-        {{/if_instance_of}}
-      </span>
     </div>
   </div>
 </li>
-{{/if_match}}
-{{/is_allowed}}
 {{/if}}
-
-{{else}}
-
-{{#if allow_mapping}}
-{{#is_allowed_to_map parent_instance model.shortName}}
-<li class="tree-item tree-item-add">
-  <div class="row-fluid">
-    <div class="span12">
-      <a
-        class="btn btn-small btn-draft"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="right"
-        data-toggle="multitype-multiselect-modal-selector"
-        data-join-mapping="{{mapping}}"
-        data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-        <i class="grcicon-add-black"></i>
-      </a>
-    </div>
-  </div>
-</li>
 {{/is_allowed_to_map}}
-{{/if}}
-{{/if_instance_of}}
-{{/if}}

--- a/src/ggrc/assets/mustache/sections/tree_footer.mustache
+++ b/src/ggrc/assets/mustache/sections/tree_footer.mustache
@@ -5,7 +5,6 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-
 <!-- {{{renderLive '/static/mustache/base_objects/tree_footer_zero.mustache'}}} -->
 
 {{#if allow_mapping_or_creating}}

--- a/src/ggrc/assets/mustache/systems/tree_footer.mustache
+++ b/src/ggrc/assets/mustache/systems/tree_footer.mustache
@@ -10,28 +10,11 @@
 
 {{#is_allowed_to_map parent_instance model.shortName}}
 {{#if allow_mapping_or_creating}}
-<li class="tree-item tree-item-add">
+<li class="tree-item tree-item-add tree-footer">
   <div class="row-fluid">
-    <div class="span12 section-expandable">
-
-      {{#if model.root_object}}
-      <a
-        class="section-add btn btn-small btn-draft"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="right"
-        data-toggle="multitype-multiselect-modal-selector"
-        data-join-mapping="{{mapping}}"
-        data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-exclude-option-types="{{exclude_option_types}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-        <i class="grcicon-add-black"></i>
-      </a>
-      <span class="section-expander">
+    <div class="span12">
         <a
-          class="section-add"
+          class="section-add btn btn-small btn-draft"
           href="javascript://"
           rel="tooltip"
           data-placement="left"
@@ -42,43 +25,8 @@
           data-join-object-type="{{parent_instance.class.shortName}}"
           data-exclude-option-types="{{exclude_option_types}}"
           data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-          Map {{model.title_singular}}
+            <i class="grcicon-add-black"></i>
         </a>
-        &nbsp;
-        &nbsp;
-        {{#if allow_creating}}
-        {{#is_allowed 'create' model.shortName context=null}}
-        <a href="{{parent_instance.viewLink}}/import_systems?return_to={{param_current_location}}" class="section-import">
-          <i class="grcicon-imp-exp"></i>
-          Import Systems
-        </a>
-        &nbsp;
-        &nbsp;
-        {{/is_allowed}}
-        {{/if}}
-        {{#if list.length}}
-        <a href="{{parent_instance.viewLink}}/export_systems?ids={{instance_ids list}}" class="section-import">
-          <i class="grcicon-export"></i>
-          Export Systems
-        </a>
-        {{/if}}
-      </span>
-      {{else}}
-      <a
-        class="section-add btn btn-small btn-draft"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="right"
-        data-toggle="multitype-multiselect-modal-selector"
-        data-join-mapping="{{mapping}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-exclude-option-types="{{exclude_option_types}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-        data-object-params='{{#if_instance_of parent_instance "Section"}}{ "section": { "id": {{parent_instance.id}}, "title": "{{json_escape parent_instance.title}}", "description": "{{json_escape parent_instance.description}}" } }{{/if_instance_of}}'>
-        <i class="grcicon-add-black"></i>
-      </a>
-      {{/if}}
     </div>
   </div>
 </li>


### PR DESCRIPTION
@arraystudio what do we do with sections? They have two different sets of import/export links. For Clauses and for Sections.