### PR TITLE
CORE 1392 Info pane not going away on tab change

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -52,6 +52,8 @@ can.Control("CMS.Controllers.InfoPin", {
     });
   },
   unsetInstance: function() {
+    // Stop the animation and clear the queue:
+    this.element.stop(true);
     this.element.html('');
     this.element.height(0);
     $('.cms_controllers_tree_view_node').removeClass('active');

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -134,7 +134,7 @@ can.Control("CMS.Controllers.TreeLoader", {
   }
 
   , show_info_pin: function() {
-    if (this.element && !this.element.data('no-pin')) {
+    if (this.element && !this.element.data('no-pin') && this.element.is(':visible')) {
       var children = this.element.children();
       children && children.find('.select').first().click();
     }

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -134,9 +134,9 @@ can.Control("CMS.Controllers.TreeLoader", {
   }
 
   , show_info_pin: function() {
-    if (this.element && !this.element.data('no-pin') && this.element.is(':visible')) {
+    if (this.element && !this.element.data('no-pin')) {
       var children = this.element.children();
-      children && children.find('.select').first().click();
+      children && children.find('.select:visible').first().click();
     }
   }
 


### PR DESCRIPTION
I found two separate issues:
Commit 1: Fixes the case when the tree list is loaded, but the active tab has changed.
Commit 2: Fixes the case where the users switches tabs before the animation completes.