### PR TITLE
Fixed for audit dashboard

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1568,7 +1568,7 @@ Mustache.registerHelper("infer_roles", function (instance, options) {
 
       // Check for contact
       if (instance.contact && instance.contact.id === person.id) {
-        state.attr('roles').push('Contact');
+        state.attr('roles').push('Audit Lead');
       }
 
       // Check for Audit roles
@@ -1580,20 +1580,6 @@ Mustache.registerHelper("infer_roles", function (instance, options) {
         refresh_queue.enqueue(requests.reify());
         refresh_queue.trigger().then(function (requests) {
           can.each(requests, function (request) {
-            var responses = request.responses || new can.Observe.List()
-              , refresh_queue = new RefreshQueue()
-              ;
-
-            refresh_queue.enqueue(responses.reify());
-            refresh_queue.trigger().then(function (responses) {
-              can.each(responses, function (response) {
-                if (response.contact && response.contact.id === person.id
-                    && !~can.inArray('Response Contact', state.attr('roles'))) {
-                  state.attr('roles').push('Response Contact');
-                }
-              });
-            });
-
             if (request.assignee && request.assignee.id === person.id
                 && !~can.inArray('Request Assignee', state.attr('roles'))) {
               state.attr('roles').push('Request Assignee');


### PR DESCRIPTION
Removed 'Response Contact' label and changed wording of 'Contact' to 'Audit Lead' for audit dashboard