### PR TITLE
Added (Disabled) keywords next to disabled owners in the info widget

### DIFF
--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -111,6 +111,11 @@
           {{#if instance.contact}}
             {{#using contact=instance.contact}}
               {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
+              {{^if contact.is_enabled}}
+                <span class="user-disabled">
+                  (Disabled)
+                </span>
+              {{/if}}
             {{/using}}
           {{else}}
             Not defined

--- a/src/ggrc/assets/mustache/base_objects/contacts.mustache
+++ b/src/ggrc/assets/mustache/base_objects/contacts.mustache
@@ -24,6 +24,11 @@
           {{#each contacts}}
             <li>
               {{{renderLive '/static/mustache/people/popover.mustache' person=this}}}
+              {{^if is_enabled}}
+                <span class="user-disabled">
+                  (Disabled)
+                </span>
+              {{/if}}
             </li>
           {{/each}}
         </ul>
@@ -42,6 +47,11 @@
       <p class="oneline">
         {{#if person}}
           {{{renderLive '/static/mustache/people/popover.mustache' person=person}}}
+          {{^if person.is_enabled}}
+            <span class="user-disabled">
+              (Disabled)
+            </span>
+          {{/if}}
         {{else}}
           <span class="error">
             Not Assigned
@@ -55,6 +65,11 @@
       <p class="oneline">
         {{#if person}}
           {{{renderLive '/static/mustache/people/popover.mustache' person=person}}}
+          {{^if person.is_enabled}}
+            <span class="user-disabled">
+              (Disabled)
+            </span>
+          {{/if}}
         {{else}}
           <span class="error">
             Not Assigned


### PR DESCRIPTION
This fix doesn't work for Program objects. 
Program will be handled in a separate issue CORE-600. 