### PR TITLE
skip objects

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -234,7 +234,7 @@ can.Model.Cacheable("CMS.Models.Audit", {
 
     try {
       if (this.contact){
-        vals['assignee'] = filter_vals.apply(this.contact.reify(), []);
+        vals['assignee'] = filter_vals.apply(this.contact.reify(), [['email', 'name']]);
       }
     } catch (e) {}
 

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1060,7 +1060,7 @@ can.Model("can.Model.Cacheable", {
               email: owner.email
             });
           });
-        } else {
+        } else if ($.type(val) === 'string'){
           values[key] = val;
         }
       }


### PR DESCRIPTION
having full objects in the filters broke full text search. 
full text search now handles just text. 