### PR TITLE
Add ControlAssessment object

### DIFF
--- a/src/ggrc/migrations/versions/20150227143259_1f7d8208aff2_add_control_assessments.py
+++ b/src/ggrc/migrations/versions/20150227143259_1f7d8208aff2_add_control_assessments.py
@@ -1,0 +1,51 @@
+
+"""Add Control Assessments
+
+Revision ID: 1f7d8208aff2
+Revises: 5254f4f31427
+Create Date: 2015-02-27 14:32:59.757944
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1f7d8208aff2'
+down_revision = '5254f4f31427'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'control_assessments',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('design', sa.Boolean(), nullable=True),
+        sa.Column('operational', sa.Boolean(), nullable=True),
+        sa.Column('os_state', sa.String(length=250), nullable=False),
+        sa.Column('test_plan', sa.Text(), nullable=True),
+        sa.Column('end_date', sa.Date(), nullable=True),
+        sa.Column('start_date', sa.Date(), nullable=True),
+        sa.Column('status', sa.String(length=250), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('url', sa.String(length=250), nullable=True),
+        sa.Column('reference_url', sa.String(length=250), nullable=True),
+        sa.Column('secondary_contact_id', sa.Integer(), nullable=True),
+        sa.Column('contact_id', sa.Integer(), nullable=True),
+        sa.Column('title', sa.String(length=250), nullable=False),
+        sa.Column('slug', sa.String(length=250), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('modified_by_id', sa.Integer(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('context_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['contact_id'], ['people.id'], ),
+        sa.ForeignKeyConstraint(['context_id'], ['contexts.id'], ),
+        sa.ForeignKeyConstraint(['secondary_contact_id'], ['people.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('slug', name='uq_control_assessments'),
+        sa.UniqueConstraint('title', name='uq_t_control_assessments')
+    )
+
+
+def downgrade():
+    op.drop_table('control_assessments')

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -13,6 +13,7 @@ from .categorization import Categorization
 from .category import CategoryBase
 from .context import Context
 from .control import Control, ControlCategory, ControlAssertion
+from .control_assessment import ControlAssessment
 from .control_control import ControlControl
 from .control_section import ControlSection
 from .custom_attribute_definition import CustomAttributeDefinition
@@ -67,6 +68,7 @@ all_models = [
     ControlAssertion,
   Context,
   Control,
+  ControlAssessment,
   ControlControl,
   ControlSection,
   CustomAttributeDefinition,

--- a/src/ggrc/models/control_assessment.py
+++ b/src/ggrc/models/control_assessment.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: anze@reciprocitylabs.com
+# Maintained By: anze@reciprocitylabs.com
+
+from ggrc import db
+from .mixins import (
+    deferred, BusinessObject, Timeboxed, CustomAttributable, TestPlanned
+)
+from .object_document import Documentable
+from .object_owner import Ownable
+from .object_person import Personable
+from .track_object_state import HasObjectState, track_state_for_class
+
+
+class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable, Documentable,
+                        Personable, Timeboxed, Ownable,
+                        BusinessObject, db.Model):
+  __tablename__ = 'control_assessments'
+
+  design = deferred(db.Column(db.Boolean), 'ControlAssessment')
+  operational = deferred(db.Column(db.Boolean), 'ControlAssessment')
+
+  # REST properties
+  _publish_attrs = [
+      'design',
+      'operational'
+  ]
+
+track_state_for_class(ControlAssessment)

--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -549,3 +549,14 @@ class CustomAttributable(object):
     #     joinstr = 'foreign(CustomAttributeDefinition.definition_type) == "{name}"'
     #     joinstr = joinstr.format(name=cls.__name__)
     #     return db.relationship("CustomAttributeDefinition",primaryjoin=joinstr)
+
+
+class TestPlanned(object):
+  @declared_attr
+  def test_plan(cls):
+    return deferred(db.Column(db.Text), cls.__name__)
+
+  # REST properties
+  _publish_attrs = ['test_plan']
+  _fulltext_attrs = ['test_plan']
+  _sanitize_html = ['test_plan']


### PR DESCRIPTION
This adds a control assessment object on the db side, but it doesn't hook it up on the frontside. We might also need a control_assessment_objects table to store all the mappings. Look at any other object in the app to see how all of this could be accomplished.

The PR also contains the TestPlanned mixin that should be added to a bunch of other objects.

Hint: for generating a table based on the object you can use the command `python ggrc/migrate.py ggrc revision --autogenerate -m "Add Control Assessments"`, but be warned that this will add columns/fixes that you don't want, so make sure you edit the created migration file.