### PR TITLE
CORE-1581 Script error when searching for objects to map

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/advanced_search_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/advanced_search_controller.js
@@ -406,7 +406,7 @@
       }
 
       option_descriptors[option_model_name] =
-        ModalOptionDescriptor.from_join_model(
+        GGRC.ModalOptionDescriptor.from_join_model(
             descriptor.model_name
           , descriptor.option_attr
           , option_model_name

--- a/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
@@ -1237,7 +1237,7 @@
 
   });
 
-  var ModalOptionDescriptor = can.Construct({
+  GGRC.ModalOptionDescriptor = can.Construct({
       model : null
     , model_display : "Objects"
     , join_model : null
@@ -1349,7 +1349,7 @@
         }
 
       option_descriptors[option_model_name] =
-        ModalOptionDescriptor.from_join_model(
+        GGRC.ModalOptionDescriptor.from_join_model(
             descriptor.model_name
           , descriptor.option_attr
           , option_model_name
@@ -2170,7 +2170,7 @@
       }
 
       option_descriptors[option_model_name] =
-        ModalOptionDescriptor.from_join_model(
+        GGRC.ModalOptionDescriptor.from_join_model(
             descriptor.model_name
           , descriptor.option_attr
           , option_model_name

--- a/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
@@ -1495,7 +1495,10 @@
         this.options.all_models = all_models;
 
         // We want All objects to be default - CORE-723
-        this.options.default_option_descriptor = 'AllObjects';
+        // But only if we actually have mutliple options - CORE-1581
+        if (all_models.length > 1) {
+          this.options.default_option_descriptor = 'AllObjects';
+        }
         // hard code some of the submenu
         // this.options.option_type_menu_2 = this.options.option_type_menu;
         this.options.option_type_menu_2 = can.map(


### PR DESCRIPTION
This fixes the two huge regressions caused by https://github.com/reciprocity/ggrc-core/pull/2557

@hyperNURb please review this and also be more diligent when refactoring code - adding that var was the right thing to do, but it caused a major breakage elsewhere in the app - a simple search/grep would prevent this from happening.