### PR TITLE
CORE-1588 Makes action list larger instead of the title

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -250,7 +250,7 @@ can.Control("CMS.Controllers.TreeLoader", {
       }
 
       // change inner tree title span4 into span8 class
-      $(".inner-tree > .tree-structure > .tree-item > .item-main").find(".row-fluid").find("[class*=span]:first").attr("class", "span8");
+      $(".inner-tree > .tree-structure > .tree-item > .item-main").find(".row-fluid").find("[class*=span]:last").attr("class", "span8");
 
     }
 
@@ -1154,4 +1154,3 @@ can.Control("CMS.Controllers.TreeViewNode", {
                             this.hash_fragment()].join('');
   }
 });
-

--- a/src/ggrc/assets/stylesheets/_widget.scss
+++ b/src/ggrc/assets/stylesheets/_widget.scss
@@ -14,9 +14,11 @@
   .tree-action-list {
     @include reset-list();
     @include clearfix();
-    float: right;
+    text-align: right;
+    height: 28px;
     li {
-      float: left;
+      display: inline-block;
+      overflow: hidden;
       margin-left: 10px;
       line-height: 24px;
       .item-data {


### PR DESCRIPTION
This should help with action list breaking into multiple lines, but it
might also make titles too small in some cases (subtrees without any
actions). See CORE-1588 for a longer discussion. 

@vladan-mitevski do you have any better ideas?