### PR TITLE
Experimental move from automatic scaling to basic scaling

### DIFF
--- a/src/app.yaml.dist
+++ b/src/app.yaml.dist
@@ -10,6 +10,10 @@ version: 1
 runtime: python27
 api_version: 1
 threadsafe: true
+instance_class: B2
+basic_scaling:
+  max_instances: 2
+  idle_timeout: 10m
 
 handlers:
   - url: /login
@@ -84,4 +88,3 @@ env_variables:
   GGRC_BOOTSTRAP_ADMIN_USERS: "{BOOTSTRAP_ADMIN_USERS}"
   GGRC_RISK_ASSESSMENT_URL: "{RISK_ASSESSMENT_URL}"
   APPENGINE_EMAIL: "{APPENGINE_EMAIL}"
-


### PR DESCRIPTION
Based on the discussion with @prasannav7, basic scaling might be a better fit for our app. Main benefits: no 60s limit for http requests, no 10min limit for task queues.

More info here: https://cloud.google.com/appengine/docs/python/modules/#scaling_types
This PR is deployed here: https://grc-epic-2.appspot.com/